### PR TITLE
feat: draw interactive SVG music notes

### DIFF
--- a/frontend/antract-frontend/package-lock.json
+++ b/frontend/antract-frontend/package-lock.json
@@ -17,7 +17,6 @@
         "@angular/router": "^19.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
-        "vexflow": "^5.0.0",
         "zone.js": "~0.15.0"
       },
       "devDependencies": {
@@ -13693,12 +13692,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/vexflow": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vexflow/-/vexflow-5.0.0.tgz",
-      "integrity": "sha512-rjB7TV4ygKE5Fl3W5OlG+0dHv22CFufUJdMG6oNgvcn0zp34u+sOboZsadQXnF1O3tZ3myXThaUIaLkJlpNM2Q==",
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.2.2",

--- a/frontend/antract-frontend/package.json
+++ b/frontend/antract-frontend/package.json
@@ -19,7 +19,6 @@
     "@angular/router": "^19.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "vexflow": "^5.0.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {

--- a/frontend/antract-frontend/src/app/drawing/draw.service.ts
+++ b/frontend/antract-frontend/src/app/drawing/draw.service.ts
@@ -71,6 +71,33 @@ export class DrawService {
       group.setAttribute('cursor', 'pointer');
 
       entries.forEach(({ entry, y }) => {
+        const top = this.staveTop;
+        const bottom = this.staveTop + 4 * this.lineSpacing;
+
+        const ledgerCountAbove = Math.max(0, Math.floor((top - y) / this.lineSpacing));
+        for (let i = 1; i <= ledgerCountAbove; i++) {
+          const ly = top - i * this.lineSpacing;
+          const ledger = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          ledger.setAttribute('x1', String(x - 12));
+          ledger.setAttribute('x2', String(x + 12));
+          ledger.setAttribute('y1', String(ly));
+          ledger.setAttribute('y2', String(ly));
+          ledger.setAttribute('stroke', 'black');
+          group.appendChild(ledger);
+        }
+
+        const ledgerCountBelow = Math.max(0, Math.floor((y - bottom) / this.lineSpacing));
+        for (let i = 1; i <= ledgerCountBelow; i++) {
+          const ly = bottom + i * this.lineSpacing;
+          const ledger = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          ledger.setAttribute('x1', String(x - 12));
+          ledger.setAttribute('x2', String(x + 12));
+          ledger.setAttribute('y1', String(ly));
+          ledger.setAttribute('y2', String(ly));
+          ledger.setAttribute('stroke', 'black');
+          group.appendChild(ledger);
+        }
+
         const ellipse = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse');
         ellipse.setAttribute('cx', String(x));
         ellipse.setAttribute('cy', String(y));

--- a/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.html
+++ b/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.html
@@ -1,6 +1,5 @@
 <div>
-    <h2>Przykład notacji muzycznej</h2>
-    <div #staff></div>
-    <div #staff2></div>
-  </div>
+  <h2>Przykład notacji muzycznej</h2>
+  <div #staff></div>
+</div>
   

--- a/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.ts
+++ b/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.ts
@@ -1,48 +1,18 @@
-  import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { Factory, GhostNote, Renderer, Stave, StaveNote } from 'vexflow';
-import { IntervalCalculateService } from '../services/interval-calculate.service';
-import { Note } from '../services/Note';
-import { TetradCalculateService } from '../services/interval-calculate/tetrad-calculate.service';
-import { FifthCalculateService } from '../services/interval-calculate/fifth-calculate.service';
+import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
 import { DrawService } from '../drawing/draw.service';
-
 
 @Component({
   selector: 'app-visual-lessons',
-  imports: [],
   templateUrl: './visual-lessons.component.html',
   styleUrl: './visual-lessons.component.css'
 })
 export class VisualLessonsComponent implements AfterViewInit {
-  @ViewChild('staff2', { static: true }) staffDivTwo!: ElementRef;
   @ViewChild('staff', { static: true }) staffDiv!: ElementRef;
 
-  private renderer!: Renderer;
-  private stave!: Stave;
-  private factories!: Factory[];
-  private notes: StaveNote[] = [];
-  constructor(private fifthCalculateService: FifthCalculateService, private drawService: DrawService) {
-    this.drawService = drawService;
-    this.fifthCalculateService = fifthCalculateService;
-  }
+  constructor(private drawService: DrawService) {}
+
   ngAfterViewInit(): void {
     this.drawService.init(this.staffDiv);
-
-    let staveNote = new StaveNote({keys: ['c/5'], duration: 'w' });
-
-    this.drawService.drawNotes([
-      new StaveNote({keys: ['c/4'], duration: 'w' }),
-      new StaveNote({keys: ['d/4'], duration: 'w' }),
-      new StaveNote({keys: ['e/4'], duration: 'w' }),
-      new StaveNote({keys: ['f/4'], duration: 'w' }),
-      new StaveNote({keys: ['g/4'], duration: 'w' }),
-      new StaveNote({keys: ['a/4'], duration: 'w' }),
-      new StaveNote({keys: ['b/4'], duration: 'w' }),
-    ]);
-
-    this.drawService.drawClickPoints(this.staffDiv);
-  }
-
-  private initializeStaff() {
   }
 }
+


### PR DESCRIPTION
## Summary
- add click-to-place notes on the staff and remove them by clicking the note
- group notes at the same x-position to form simple chords with a shared stem
- simplify visual lesson component to start with an empty interactive staff

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b85eb84c832f867123e869c4653f