### PR TITLE
Improve chord layout and add note editing controls

### DIFF
--- a/frontend/antract-frontend/src/app/drawing/draw.service.ts
+++ b/frontend/antract-frontend/src/app/drawing/draw.service.ts
@@ -214,22 +214,22 @@ export class DrawService {
         }
       });
 
-      if (sortedEntries.length === 1) {
+      if (sortedEntries.length > 0) {
         const stem = document.createElementNS('http://www.w3.org/2000/svg', 'line');
         stem.setAttribute('stroke', 'black');
         stem.setAttribute('stroke-width', '1');
         const topY = Math.min(...ys);
         const bottomY = Math.max(...ys);
-        if (topY < middleY) {
-          const stemX = Math.min(...noteXs) - 5;
-          stem.setAttribute('x1', String(stemX));
-          stem.setAttribute('x2', String(stemX));
+        const stemDown = topY < middleY;
+        const stemX = stemDown
+          ? Math.min(...noteXs) - 5
+          : Math.max(...noteXs) + 5;
+        stem.setAttribute('x1', String(stemX));
+        stem.setAttribute('x2', String(stemX));
+        if (stemDown) {
           stem.setAttribute('y1', String(topY));
           stem.setAttribute('y2', String(bottomY + 35));
         } else {
-          const stemX = Math.max(...noteXs) + 5;
-          stem.setAttribute('x1', String(stemX));
-          stem.setAttribute('x2', String(stemX));
           stem.setAttribute('y1', String(bottomY));
           stem.setAttribute('y2', String(topY - 35));
         }

--- a/frontend/antract-frontend/src/app/drawing/draw.service.ts
+++ b/frontend/antract-frontend/src/app/drawing/draw.service.ts
@@ -109,16 +109,9 @@ export class DrawService {
       return [0];
     }
     const offsets: number[] = [];
-    let leftSteps = 0;
-    let rightSteps = 0;
     for (let i = 0; i < count; i++) {
-      if (i % 2 === 0) {
-        leftSteps += 1;
-        offsets.push(-this.chordOffsetSpacing * leftSteps);
-      } else {
-        rightSteps += 1;
-        offsets.push(this.chordOffsetSpacing * rightSteps);
-      }
+      const direction = i % 2 === 0 ? -1 : 1;
+      offsets.push(direction * this.chordOffsetSpacing);
     }
     return offsets;
   }

--- a/frontend/antract-frontend/src/app/drawing/draw.service.ts
+++ b/frontend/antract-frontend/src/app/drawing/draw.service.ts
@@ -221,7 +221,7 @@ export class DrawService {
         }
       });
 
-      if (sortedEntries.length > 0) {
+      if (sortedEntries.length === 1) {
         const stem = document.createElementNS('http://www.w3.org/2000/svg', 'line');
         stem.setAttribute('stroke', 'black');
         stem.setAttribute('stroke-width', '1');

--- a/frontend/antract-frontend/src/app/drawing/draw.service.ts.lines
+++ b/frontend/antract-frontend/src/app/drawing/draw.service.ts.lines
@@ -1,0 +1,388 @@
+1: import { ElementRef, Injectable } from '@angular/core';
+2: import { BehaviorSubject } from 'rxjs';
+3: import { Note } from '../services/Note';
+4: 
+5: @Injectable({
+6:   providedIn: 'root'
+7: })
+8: export class DrawService {
+9:   private svg!: SVGSVGElement;
+10:   private notes: { note: Note; index: number }[] = [];
+11:   private selectedEntry: { note: Note; index: number } | null = null;
+12:   private readonly selectedNoteSubject = new BehaviorSubject<{ note: Note; index: number } | null>(null);
+13: 
+14:   public readonly selectedNote$ = this.selectedNoteSubject.asObservable();
+15: 
+16:   private readonly width = 500;
+17:   private readonly height = 200;
+18:   private readonly staveLeft = 10;
+19:   private readonly staveTop = 40;
+20:   private readonly lineSpacing = 10;
+21:   private readonly noteSpacing = 40;
+22:   private readonly chordOffsetSpacing = 6;
+23:   
+24:   private readonly stepMap: Record<string, number> = {
+25:     'C': 0,
+26:     'D': 1,
+27:     'E': 2,
+28:     'F': 3,
+29:     'G': 4,
+30:     'A': 5,
+31:     'H': 6
+32:   };
+33: 
+34:   constructor() {}
+35: 
+36:   public init(elementRef: ElementRef): void {
+37:     this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+38:     this.svg.setAttribute('width', `${this.width}`);
+39:     this.svg.setAttribute('height', `${this.height}`);
+40:     elementRef.nativeElement.innerHTML = '';
+41:     elementRef.nativeElement.appendChild(this.svg);
+42:     this.drawStaff();
+43: 
+44:     this.svg.addEventListener('click', (e) => this.handleSvgClick(e));
+45:   }
+46: 
+47:   public addNote(note: Note, index: number): void {
+48:     // Prevent duplicate staff positions within the same chord column
+49:     const newSteps = this.getStepsFromC4(note);
+50:     const existing = this.notes.find(e => e.index === index && this.getStepsFromC4(e.note) === newSteps);
+51:     if (existing) {
+52:       // Select existing instead of placing a second head next to it
+53:       this.setSelectedEntry(existing, false);
+54:       return;
+55:     }
+56:     const entry = { note, index };
+57:     this.notes.push(entry);
+58:     this.setSelectedEntry(entry, false);
+59:     this.redraw();
+60:   }
+61: 
+62:   public drawNotes(notes: Note[]): void {
+63:     this.notes = notes.map((n, i) => ({ note: n, index: i }));
+64:     this.setSelectedEntry(null, false);
+65:     this.redraw();
+66:   }
+67: 
+68:   private handleSvgClick(event: MouseEvent): void {
+69:     if (event.target !== this.svg) {
+70:       return; // avoid adding when clicking on notes
+71:     }
+72:     const rect = this.svg.getBoundingClientRect();
+73:     const x = event.clientX - rect.left;
+74:     const y = event.clientY - rect.top;
+75:     const index = Math.round((x - this.staveLeft) / this.noteSpacing);
+76:     const note = this.getNoteFromY(y);
+77:     // Delegate to addNote, which enforces deduplication per staff position
+78:     this.addNote(note, index);
+79:   }
+80: 
+81:   public clearSelection(): void {
+82:     if (!this.selectedEntry) {
+83:       return;
+84:     }
+85:     this.setSelectedEntry(null);
+86:   }
+87: 
+88:   public deleteSelectedNote(): void {
+89:     if (!this.selectedEntry) {
+90:       return;
+91:     }
+92:     const idx = this.notes.indexOf(this.selectedEntry);
+93:     if (idx > -1) {
+94:       this.notes.splice(idx, 1);
+95:     }
+96:     this.setSelectedEntry(null, true);
+97:     this.redraw();
+98:   }
+99: 
+100:   public transposeSelected(delta: number): void {
+101:     if (!this.selectedEntry || delta === 0) {
+102:       return;
+103:     }
+104:     this.selectedEntry.note.transposeSemitone(delta);
+105:     this.selectedNoteSubject.next({
+106:       note: this.selectedEntry.note,
+107:       index: this.selectedEntry.index
+108:     });
+109:     this.redraw();
+110:   }
+111: 
+112:   private setSelectedEntry(
+113:     entry: { note: Note; index: number } | null,
+114:     skipRedraw = false
+115:   ): void {
+116:     this.selectedEntry = entry;
+117:     this.selectedNoteSubject.next(entry ? { note: entry.note, index: entry.index } : null);
+118:     if (!skipRedraw && this.svg) {
+119:       this.redraw();
+120:     }
+121:   }
+122: 
+123:   private computeChordOffsets(
+124:     entries: { entry: { note: Note; index: number }; y: number }[],
+125:     stemDown: boolean,
+126:     placeStemBetween: boolean
+127:   ): number[] {
+128:     const count = entries.length;
+129:     if (count === 0) {
+130:       return [];
+131:     }
+132: 
+133:     const offsets = new Array<number>(count).fill(0);
+134:     if (count === 1) {
+135:       return offsets;
+136:     }
+137: 
+138:     const steps = entries.map(({ entry }) => this.getStepsFromC4(entry.note));
+139: 
+140:     let clusterStart = 0;
+141:     while (clusterStart < count) {
+142:       let clusterEnd = clusterStart;
+143:       while (clusterEnd + 1 < count) {
+144:         const diff = Math.abs(steps[clusterEnd + 1] - steps[clusterEnd]);
+145:         if (diff === 0 || diff === 1) {
+146:           clusterEnd++;
+147:         } else {
+148:           break;
+149:         }
+150:       }
+151: 
+152:       if (clusterEnd > clusterStart) {
+153:         // Music engraving convention:
+154:         // - Stem up: higher note heads go to the right.
+155:         // - Stem down: lower note heads go to the right.
+156:         // 'entries' are sorted low -> high by y (descending y), so
+157:         // we start clusters with the lowest note at clusterStart.
+158:         if (stemDown) {
+159:           // Start on the right for the lowest note, then alternate.
+160:           let offset = this.chordOffsetSpacing; // right
+161:           for (let i = clusterStart; i <= clusterEnd; i++) {
+162:             offsets[i] = offset;
+163:             offset = offset === this.chordOffsetSpacing ? -this.chordOffsetSpacing : this.chordOffsetSpacing;
+164:           }
+165:         } else {
+166:           // Start on the left for the lowest note, then alternate.
+167:           let offset = -this.chordOffsetSpacing; // left
+168:           for (let i = clusterStart; i <= clusterEnd; i++) {
+169:             offsets[i] = offset;
+170:             offset = offset === -this.chordOffsetSpacing ? this.chordOffsetSpacing : -this.chordOffsetSpacing;
+171:           }
+172:         }
+173:       }
+174: 
+175:       clusterStart = clusterEnd + 1;
+176:     }
+177: 
+178:     // If the stem will be centered between noteheads (e.g., when a
+179:     // second/unison exists), ensure no note remains centered on the
+180:     // stem line. We do this by assigning sides to all remaining notes
+181:     // (those not already offset within a tight cluster), alternating
+182:     // left/right from the lowest note upward. The starting side follows
+183:     // engraving rules: stem up -> lowest note left; stem down -> lowest
+184:     // note right.
+185:     if (placeStemBetween) {
+186:       let currentSide = stemDown ? this.chordOffsetSpacing : -this.chordOffsetSpacing;
+187:       for (let i = 0; i < count; i++) {
+188:         if (offsets[i] === 0) {
+189:           offsets[i] = currentSide;
+190:           currentSide = -currentSide;
+191:         } else {
+192:           // Continue alternating based on the actual sign used.
+193:           currentSide = offsets[i] > 0 ? -this.chordOffsetSpacing : this.chordOffsetSpacing;
+194:         }
+195:       }
+196:     }
+197: 
+198:     return offsets;
+199:   }
+200:   
+201: 
+202:   private redraw(): void {
+203:     if (!this.svg) {
+204:       return;
+205:     }
+206:     this.svg.innerHTML = '';
+207:     this.drawStaff();
+208: 
+209:     const notesByIndex = new Map<number, { entry: { note: Note; index: number }; y: number }[]>();
+210:     this.notes.forEach((entry) => {
+211:       const y = this.getYForNote(entry.note);
+212:       const arr = notesByIndex.get(entry.index) || [];
+213:       // Avoid placing two heads on the same staff position within one index
+214:       const steps = this.getStepsFromC4(entry.note);
+215:       const existsSamePos = arr.some(e => this.getStepsFromC4(e.entry.note) === steps);
+216:       if (!existsSamePos) {
+217:         arr.push({ entry, y });
+218:         notesByIndex.set(entry.index, arr);
+219:       }
+220:     });
+221: 
+222:     const middleY = this.staveTop + 2 * this.lineSpacing;
+223: 
+224:     notesByIndex.forEach((entries, idx) => {
+225:       const baseX = this.staveLeft + idx * this.noteSpacing;
+226:       const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+227:       group.setAttribute('cursor', 'pointer');
+228: 
+229:       const sortedEntries = entries.slice().sort((a, b) => b.y - a.y);
+230:       let stemDown = false;
+231:       if (sortedEntries.length > 0) {
+232:         const topYPosition = Math.min(...sortedEntries.map((entry) => entry.y));
+233:         stemDown = topYPosition < middleY;
+234:       }
+235:       // Determine if chord contains at least one second/unison to decide
+236:       // whether the stem should be centered between noteheads.
+237:       const stepSeq = sortedEntries.map(({ entry }) => this.getStepsFromC4(entry.note));
+238:       let hasSecond = false;
+239:       for (let i = 0; i + 1 < stepSeq.length; i++) {
+240:         const d = Math.abs(stepSeq[i + 1] - stepSeq[i]);
+241:         if (d <= 1) { hasSecond = true; break; }
+242:       }
+243:       const offsets = this.computeChordOffsets(sortedEntries, stemDown, hasSecond);
+244:       const noteXs: number[] = [];
+245:       const ys: number[] = [];
+246: 
+247:       sortedEntries.forEach(({ entry, y }, chordIdx) => {
+248:         const offset = offsets[chordIdx] ?? 0;
+249:         const noteX = baseX + offset;
+250:         noteXs.push(noteX);
+251:         ys.push(y);
+252: 
+253:         const top = this.staveTop;
+254:         const bottom = this.staveTop + 4 * this.lineSpacing;
+255: 
+256:         const ledgerCountAbove = Math.max(0, Math.floor((top - y) / this.lineSpacing));
+257:         for (let i = 1; i <= ledgerCountAbove; i++) {
+258:           const ly = top - i * this.lineSpacing;
+259:           const ledger = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+260:           ledger.setAttribute('x1', String(noteX - 12));
+261:           ledger.setAttribute('x2', String(noteX + 12));
+262:           ledger.setAttribute('y1', String(ly));
+263:           ledger.setAttribute('y2', String(ly));
+264:           ledger.setAttribute('stroke', 'black');
+265:           group.appendChild(ledger);
+266:         }
+267: 
+268:         const ledgerCountBelow = Math.max(0, Math.floor((y - bottom) / this.lineSpacing));
+269:         for (let i = 1; i <= ledgerCountBelow; i++) {
+270:           const ly = bottom + i * this.lineSpacing;
+271:           const ledger = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+272:           ledger.setAttribute('x1', String(noteX - 12));
+273:           ledger.setAttribute('x2', String(noteX + 12));
+274:           ledger.setAttribute('y1', String(ly));
+275:           ledger.setAttribute('y2', String(ly));
+276:           ledger.setAttribute('stroke', 'black');
+277:           group.appendChild(ledger);
+278:         }
+279: 
+280:         const ellipse = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse');
+281:         ellipse.setAttribute('cx', String(noteX));
+282:         ellipse.setAttribute('cy', String(y));
+283:         ellipse.setAttribute('rx', '7');
+284:         ellipse.setAttribute('ry', '5');
+285:         ellipse.setAttribute('fill', 'black');
+286:         ellipse.setAttribute('transform', `rotate(-20 ${noteX} ${y})`);
+287:         if (this.selectedEntry === entry) {
+288:           ellipse.setAttribute('stroke', '#ff5722');
+289:           ellipse.setAttribute('stroke-width', '2');
+290:         } else {
+291:           ellipse.setAttribute('stroke', 'none');
+292:           ellipse.setAttribute('stroke-width', '0');
+293:         }
+294:         ellipse.addEventListener('click', (ev) => {
+295:           ev.stopPropagation();
+296:           this.setSelectedEntry(entry);
+297:         });
+298:         group.appendChild(ellipse);
+299: 
+300:         const accidentalSymbol = entry.note.getAccidentalSymbol();
+301:         if (accidentalSymbol) {
+302:           const accidental = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+303:           accidental.textContent = accidentalSymbol;
+304:           accidental.setAttribute('x', String(noteX - 14));
+305:           accidental.setAttribute('y', String(y));
+306:           accidental.setAttribute('font-size', '16');
+307:           accidental.setAttribute('font-family', 'serif');
+308:           accidental.setAttribute('dominant-baseline', 'middle');
+309:           accidental.setAttribute('text-anchor', 'middle');
+310:           accidental.addEventListener('click', (ev) => {
+311:             ev.stopPropagation();
+312:             this.setSelectedEntry(entry);
+313:           });
+314:           group.appendChild(accidental);
+315:         }
+316:       });
+317: 
+318:       if (sortedEntries.length > 0) {
+319:         const stem = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+320:         stem.setAttribute('stroke', 'black');
+321:         stem.setAttribute('stroke-width', '1');
+322:         const topY = Math.min(...ys);
+323:         const bottomY = Math.max(...ys);
+324:         // Place the stem between noteheads when they are displaced
+325:         // on both sides (e.g., seconds). Otherwise keep outside.
+326:         const minX = Math.min(...noteXs);
+327:         const maxX = Math.max(...noteXs);
+328:         const stemX = hasSecond ? baseX : (stemDown ? minX - 5 : maxX + 5);
+329:         stem.setAttribute('x1', String(stemX));
+330:         stem.setAttribute('x2', String(stemX));
+331:         if (stemDown) {
+332:           stem.setAttribute('y1', String(topY));
+333:           stem.setAttribute('y2', String(bottomY + 35));
+334:         } else {
+335:           stem.setAttribute('y1', String(bottomY));
+336:           stem.setAttribute('y2', String(topY - 35));
+337:         }
+338:         group.appendChild(stem);
+339:       }
+340: 
+341:       this.svg.appendChild(group);
+342:     });
+343:   }
+344: 
+345:   
+346: 
+347:   private drawStaff(): void {
+348:     for (let i = 0; i < 5; i++) {
+349:       const y = this.staveTop + i * this.lineSpacing;
+350:       const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+351:       line.setAttribute('x1', String(this.staveLeft));
+352:       line.setAttribute('x2', String(this.width - this.staveLeft));
+353:       line.setAttribute('y1', String(y));
+354:       line.setAttribute('y2', String(y));
+355:       line.setAttribute('stroke', 'black');
+356:       this.svg.appendChild(line);
+357:     }
+358:   }
+359: 
+360:   private getYForNote(note: Note): number {
+361:     const stepsFromC4 = this.getStepsFromC4(note);
+362:     // bottom line of the staff corresponds to E4 (2 steps above C4)
+363:     return (
+364:       this.staveTop +
+365:       4 * this.lineSpacing -
+366:       (stepsFromC4 - 2) * (this.lineSpacing / 2)
+367:     );
+368:   }
+369: 
+370:   private getStepsFromC4(note: Note): number {
+371:     return this.stepMap[note.getLetter()] + (note.getOctave() - 4) * 7;
+372:   }
+373: 
+374:   private getNoteFromY(y: number): Note {
+375:     // adjust by 2 steps so bottom line maps to E4
+376:     const stepsFromC4 =
+377:       Math.round(
+378:         (this.staveTop + 4 * this.lineSpacing - y) /
+379:           (this.lineSpacing / 2)
+380:       ) + 2;
+381:     const letters = ['C', 'D', 'E', 'F', 'G', 'A', 'H'];
+382:     const letter = letters[((stepsFromC4 % 7) + 7) % 7];
+383:     const octave = 4 + Math.floor(stepsFromC4 / 7);
+384:     return new Note(0, letter, octave);
+385:   }
+386: 
+387: }
+388: 

--- a/frontend/antract-frontend/src/app/services/Note.ts
+++ b/frontend/antract-frontend/src/app/services/Note.ts
@@ -1,229 +1,318 @@
-    export class Note {
+export class Note {
+  private pitch: number;
+  private letter: string;
+  private octave: number;
 
-        constructor(pitch: number, letter: string, octave: number = 0) {
-            this.octave = octave;
-            this.pitch = pitch;
-            this.letter = letter;
-        }
+  private static readonly letterSemitones: { [key: string]: number } = {
+    C: 0,
+    D: 2,
+    E: 4,
+    F: 5,
+    G: 7,
+    A: 9,
+    H: 11
+  };
 
-        private pitch: number;
-        private letter: string;
-        private octave: number;
+  private static readonly letterOrder: string[] = ['C', 'D', 'E', 'F', 'G', 'A', 'H'];
 
-        private static readonly letterSemitones: { [key: string]: number } = {
-            'C': 0,
-            'D': 2,
-            'E': 4,
-            'F': 5,
-            'G': 7,
-            'A': 9,
-            'H': 11
-        }
+  constructor(pitch: number, letter: string, octave: number = 0) {
+    this.octave = octave;
+    this.pitch = pitch;
+    this.letter = letter;
+  }
 
-        public getSemitone(letter: string): number {
-            return Note.letterSemitones[letter];
-        }
+  private static resolveOctaveAndPitch(totalSemitone: number, letter: string): {
+    octave: number;
+    pitch: number;
+  } {
+    const base = Note.letterSemitones[letter];
+    let octave = Math.round((totalSemitone - base) / 12);
+    let pitch = totalSemitone - (octave * 12 + base);
 
-        public getPitch(): number {
-            return this.pitch;
-        }
-
-        public setPitch(newOctave: number): void {
-            this.pitch = newOctave;
-        }
-
-        public getLetter(): string {
-            return this.letter;
-        }
-
-        public setLetter(newNote: string): void {
-            this.letter = newNote;
-        }
-
-        public getOctave(): number {
-            return this.octave;
-        }
-
-        public setOctave(newOctave: number): void {
-            this.octave = newOctave;
-        }
-
-        public addInterval(semitoneDistance: number, noteNumber: number) {
-
-        let notes: string[] = ['C', "D", "E", "F", "G", "A", "H"];
-
-        const targetNote: string = notes[((notes.indexOf(this.getLetter()) + (noteNumber - Math.sign(noteNumber)) % notes.length + notes.length) % notes.length)];
-        console.log(`Target note: ${(notes.indexOf(this.getLetter()) + (noteNumber - Math.sign(noteNumber)) + notes.length) % notes.length}`);
-        let targetOctave: number = this.getOctave();
-
-        let startNoteSemitone: number = this.getSemitone(this.getLetter()) + this.getPitch();
-        let targetNoteSemitone: number = this.getSemitone(targetNote);
-
-        if (startNoteSemitone > targetNoteSemitone && semitoneDistance > 0) {
-                targetOctave += 1;
-                targetNoteSemitone += 12;
-        } else if (startNoteSemitone < targetNoteSemitone && semitoneDistance < 0) {
-                targetOctave -= 1;
-                targetNoteSemitone -= 12;
-        }
-
-        if (semitoneDistance >= 12 || semitoneDistance <= -12) {
-            if (semitoneDistance >= 12) {
-                targetOctave += Math.floor(semitoneDistance / 12);
-            } else if (semitoneDistance <= -12) {
-                targetOctave += Math.ceil(semitoneDistance / 12);
-            }
-            semitoneDistance = semitoneDistance % 12;
-        }
-
-        const naturalSemitoneOffset: number = (targetNoteSemitone - startNoteSemitone);
-        const difference: number = semitoneDistance - naturalSemitoneOffset;
-
-        return new Note(difference, targetNote, targetOctave);
+    while (pitch > 1) {
+      octave += 1;
+      pitch = totalSemitone - (octave * 12 + base);
     }
 
-        toString(): string {
-        const letterName = this.letter
-        const acc = this.pitch;
-        if (acc === 0) {
-        return letterName + `Octave: ${this.octave}`;
-        } else if (acc > 0) {
-        // np. +2 -> 'isis'
-        return letterName + 'is'.repeat(acc) + `Octave: ${this.octave}`;
-        } else { // acc < 0
-        const flats = -acc;
-        if (flats === 1) {
-            if (letterName === 'A' || letterName === 'E') return letterName + 's' + `Octave: ${this.octave}`;
-            if (letterName === 'H') return 'B' + `Octave: ${this.octave}`;  // H + bemol -> B (lub 'Hes')
-            return letterName + 'es' + `Octave: ${this.octave}`;
+    while (pitch < -1) {
+      octave -= 1;
+      pitch = totalSemitone - (octave * 12 + base);
+    }
+
+    return { octave, pitch };
+  }
+
+  private getTotalSemitone(): number {
+    return this.octave * 12 + Note.letterSemitones[this.letter] + this.pitch;
+  }
+
+  public getSemitone(letter: string): number {
+    return Note.letterSemitones[letter];
+  }
+
+  public getPitch(): number {
+    return this.pitch;
+  }
+
+  public setPitch(newOctave: number): void {
+    this.pitch = newOctave;
+  }
+
+  public getLetter(): string {
+    return this.letter;
+  }
+
+  public setLetter(newNote: string): void {
+    this.letter = newNote;
+  }
+
+  public getOctave(): number {
+    return this.octave;
+  }
+
+  public setOctave(newOctave: number): void {
+    this.octave = newOctave;
+  }
+
+  public transposeSemitone(distance: number): void {
+    if (distance === 0) {
+      return;
+    }
+
+    if (distance > 0) {
+      for (let i = 0; i < distance; i++) {
+        this.raiseOneSemitone();
+      }
+    } else {
+      for (let i = 0; i < Math.abs(distance); i++) {
+        this.lowerOneSemitone();
+      }
+    }
+  }
+
+  private raiseOneSemitone(): void {
+    const total = this.getTotalSemitone() + 1;
+
+    if (this.pitch < 1) {
+      this.pitch += 1;
+      return;
+    }
+
+    const currentIndex = Note.letterOrder.indexOf(this.letter);
+    const nextIndex = (currentIndex + 1) % Note.letterOrder.length;
+    const nextLetter = Note.letterOrder[nextIndex];
+    const { octave, pitch } = Note.resolveOctaveAndPitch(total, nextLetter);
+
+    this.letter = nextLetter;
+    this.octave = octave;
+    this.pitch = pitch;
+  }
+
+  private lowerOneSemitone(): void {
+    const total = this.getTotalSemitone() - 1;
+
+    if (this.pitch > -1) {
+      this.pitch -= 1;
+      return;
+    }
+
+    const currentIndex = Note.letterOrder.indexOf(this.letter);
+    const prevIndex = (currentIndex - 1 + Note.letterOrder.length) % Note.letterOrder.length;
+    const prevLetter = Note.letterOrder[prevIndex];
+    const { octave, pitch } = Note.resolveOctaveAndPitch(total, prevLetter);
+
+    this.letter = prevLetter;
+    this.octave = octave;
+    this.pitch = pitch;
+  }
+
+  public getAccidentalSymbol(): string {
+    if (this.pitch === 0) {
+      return '';
+    }
+
+    if (this.pitch > 0) {
+      return '♯'.repeat(this.pitch);
+    }
+
+    return '♭'.repeat(Math.abs(this.pitch));
+  }
+
+  public addInterval(semitoneDistance: number, noteNumber: number) {
+
+    let notes: string[] = ['C', "D", "E", "F", "G", "A", "H"];
+
+    const targetNote: string = notes[((notes.indexOf(this.getLetter()) + (noteNumber - Math.sign(noteNumber)) % notes.length
+ + notes.length) % notes.length)];
+    console.log(`Target note: ${(notes.indexOf(this.getLetter()) + (noteNumber - Math.sign(noteNumber)) + notes.length) % notes.length}`);
+    let targetOctave: number = this.getOctave();
+
+    let startNoteSemitone: number = this.getSemitone(this.getLetter()) + this.getPitch();
+    let targetNoteSemitone: number = this.getSemitone(targetNote);
+
+    if (startNoteSemitone > targetNoteSemitone && semitoneDistance > 0) {
+      targetOctave += 1;
+      targetNoteSemitone += 12;
+    } else if (startNoteSemitone < targetNoteSemitone && semitoneDistance < 0) {
+      targetOctave -= 1;
+      targetNoteSemitone -= 12;
+    }
+
+    if (semitoneDistance >= 12 || semitoneDistance <= -12) {
+      if (semitoneDistance >= 12) {
+        targetOctave += Math.floor(semitoneDistance / 12);
+      } else if (semitoneDistance <= -12) {
+        targetOctave += Math.ceil(semitoneDistance / 12);
+      }
+      semitoneDistance = semitoneDistance % 12;
+    }
+
+    const naturalSemitoneOffset: number = (targetNoteSemitone - startNoteSemitone);
+    const difference: number = semitoneDistance - naturalSemitoneOffset;
+
+    return new Note(difference, targetNote, targetOctave);
+  }
+
+  toString(): string {
+    const letterName = this.letter;
+    const acc = this.pitch;
+    if (acc === 0) {
+      return letterName + `Octave: ${this.octave}`;
+    } else if (acc > 0) {
+      return letterName + 'is'.repeat(acc) + `Octave: ${this.octave}`;
+    } else {
+      const flats = -acc;
+      if (flats === 1) {
+        if (letterName === 'A' || letterName === 'E') return letterName + 's' + `Octave: ${this.octave}`;
+        if (letterName === 'H') return 'B' + `Octave: ${this.octave}`;
+        return letterName + 'es' + `Octave: ${this.octave}`;
+      } else {
+        let suffix = '';
+        if (letterName === 'A' || letterName === 'E') {
+          suffix = 's' + 'es'.repeat(flats - 1);
+        } else if (letterName === 'H') {
+          suffix = 'es'.repeat(flats);
         } else {
-            // 2 lub więcej bemoli
-            let suffix = '';
-            if (letterName === 'A' || letterName === 'E') {
-            suffix = 's' + 'es'.repeat(flats - 1);    // Ases, Eses, Aseses (teoretycznie)
-            } else if (letterName === 'H') {
-            suffix = 'es'.repeat(flats);             // Hes, Heses
-            } else {
-            suffix = 'es'.repeat(flats);             // Ces, Ceses, itd.
-            }
-            return letterName + suffix + `Octave: ${this.octave}`;
+          suffix = 'es'.repeat(flats);
         }
-        }
+        return letterName + suffix + `Octave: ${this.octave}`;
+      }
     }
+  }
 
-    public calculateUnison(): Note {
-        return this.addInterval(0, 1);
-    }
+  public calculateUnison(): Note {
+    return this.addInterval(0, 1);
+  }
 
-    public calculateMinorSecond(): Note {
-        return this.addInterval(1, 2);
-    }
+  public calculateMinorSecond(): Note {
+    return this.addInterval(1, 2);
+  }
 
-    public calculateMajorSecond(): Note {
-        return this.addInterval(2, 2);
-    }
+  public calculateMajorSecond(): Note {
+    return this.addInterval(2, 2);
+  }
 
-    public calculateMinorThird(): Note {
-        return this.addInterval(3, 3);
-    }
+  public calculateMinorThird(): Note {
+    return this.addInterval(3, 3);
+  }
 
-    public calculateMajorThird(): Note {
-        return this.addInterval(4, 3);
-    }
+  public calculateMajorThird(): Note {
+    return this.addInterval(4, 3);
+  }
 
-    public calculatePerfectFourth(): Note {
-        return this.addInterval(5, 4);
-    }
+  public calculatePerfectFourth(): Note {
+    return this.addInterval(5, 4);
+  }
 
-    public calculateAugmentedFourth(): Note {
-        return this.addInterval(6, 4);
-    }
+  public calculateAugmentedFourth(): Note {
+    return this.addInterval(6, 4);
+  }
 
-    public calculateDiminishedFourth(): Note {
-        return this.addInterval(4, 4);
-    }
+  public calculateDiminishedFourth(): Note {
+    return this.addInterval(4, 4);
+  }
 
-    public calculateDiminishedFifth(): Note {
-        return this.addInterval(6, 5);
-    }
+  public calculateDiminishedFifth(): Note {
+    return this.addInterval(6, 5);
+  }
 
-    public calculatePerfectFifth(): Note {
-        return this.addInterval(7, 5);
-    }
+  public calculatePerfectFifth(): Note {
+    return this.addInterval(7, 5);
+  }
 
-    public calculateMinorSixth(): Note {
-        return this.addInterval(8, 6);
-    }
+  public calculateMinorSixth(): Note {
+    return this.addInterval(8, 6);
+  }
 
-    public calculateMajorSixth(): Note {
-        return this.addInterval(9, 6);
-    }
+  public calculateMajorSixth(): Note {
+    return this.addInterval(9, 6);
+  }
 
-    public calculateMinorSeventh(): Note {
-        return this.addInterval(10, 7);
-    }
+  public calculateMinorSeventh(): Note {
+    return this.addInterval(10, 7);
+  }
 
-    public calculateMajorSeventh(): Note {
-        return this.addInterval(11, 7);
-    }
+  public calculateMajorSeventh(): Note {
+    return this.addInterval(11, 7);
+  }
 
-    public calculatePerfectOctave(): Note {
-        return this.addInterval(12, 8);
-    }
+  public calculatePerfectOctave(): Note {
+    return this.addInterval(12, 8);
+  }
 
-    public calculateMinorNinth(): Note {
-        return this.addInterval(13, 9);
-    }
+  public calculateMinorNinth(): Note {
+    return this.addInterval(13, 9);
+  }
 
-    public calculateMajorNinth(): Note {
-        return this.addInterval(14, 9);
-    }
+  public calculateMajorNinth(): Note {
+    return this.addInterval(14, 9);
+  }
 
-    public calculateMinorTenth(): Note {
-        return this.addInterval(15, 10);
-    }
+  public calculateMinorTenth(): Note {
+    return this.addInterval(15, 10);
+  }
 
-    public calculateMajorTenth(): Note {
-        return this.addInterval(16, 10);
-    }
+  public calculateMajorTenth(): Note {
+    return this.addInterval(16, 10);
+  }
 
-    public calculatePerfectEleventh(): Note {
-        return this.addInterval(17, 11);
-    }
+  public calculatePerfectEleventh(): Note {
+    return this.addInterval(17, 11);
+  }
 
-    public calculateAugmentedEleventh(): Note {
-        return this.addInterval(18, 11);
-    }
+  public calculateAugmentedEleventh(): Note {
+    return this.addInterval(18, 11);
+  }
 
-    public calculateDiminishedTwelfth(): Note {
-        return this.addInterval(18, 12);
-    }
+  public calculateDiminishedTwelfth(): Note {
+    return this.addInterval(18, 12);
+  }
 
-    public calculatePerfectTwelfth(): Note {
-        return this.addInterval(19, 12);
-    }
+  public calculatePerfectTwelfth(): Note {
+    return this.addInterval(19, 12);
+  }
 
-    public calculateMinorThirteenth(): Note {
-        return this.addInterval(20, 13);
-    }
+  public calculateMinorThirteenth(): Note {
+    return this.addInterval(20, 13);
+  }
 
-    public calculateMajorThirteenth(): Note {
-        return this.addInterval(21, 13);
-    }
+  public calculateMajorThirteenth(): Note {
+    return this.addInterval(21, 13);
+  }
 
-    public calculateMinorFourteenth(): Note {
-        return this.addInterval(22, 14);
-    }
+  public calculateMinorFourteenth(): Note {
+    return this.addInterval(22, 14);
+  }
 
-    public calculateMajorFourteenth(): Note {
-        return this.addInterval(23, 14);
-    }
+  public calculateMajorFourteenth(): Note {
+    return this.addInterval(23, 14);
+  }
 
-    public calculatePerfectFifteenth(): Note {
-        return this.addInterval(24, 15);
-    }
+  public calculatePerfectFifteenth(): Note {
+    return this.addInterval(24, 15);
+  }
 
-    public calculateKwintaDown(): Note {
-        return this.addInterval(-7, -5);
-    }
-    }
+  public calculateKwintaDown(): Note {
+    return this.addInterval(-7, -5);
+  }
+}

--- a/frontend/antract-frontend/src/app/services/Note.ts.lines
+++ b/frontend/antract-frontend/src/app/services/Note.ts.lines
@@ -1,0 +1,318 @@
+1: export class Note {
+2:   private pitch: number;
+3:   private letter: string;
+4:   private octave: number;
+5: 
+6:   private static readonly letterSemitones: { [key: string]: number } = {
+7:     C: 0,
+8:     D: 2,
+9:     E: 4,
+10:     F: 5,
+11:     G: 7,
+12:     A: 9,
+13:     H: 11
+14:   };
+15: 
+16:   private static readonly letterOrder: string[] = ['C', 'D', 'E', 'F', 'G', 'A', 'H'];
+17: 
+18:   constructor(pitch: number, letter: string, octave: number = 0) {
+19:     this.octave = octave;
+20:     this.pitch = pitch;
+21:     this.letter = letter;
+22:   }
+23: 
+24:   private static resolveOctaveAndPitch(totalSemitone: number, letter: string): {
+25:     octave: number;
+26:     pitch: number;
+27:   } {
+28:     const base = Note.letterSemitones[letter];
+29:     let octave = Math.round((totalSemitone - base) / 12);
+30:     let pitch = totalSemitone - (octave * 12 + base);
+31: 
+32:     while (pitch > 1) {
+33:       octave += 1;
+34:       pitch = totalSemitone - (octave * 12 + base);
+35:     }
+36: 
+37:     while (pitch < -1) {
+38:       octave -= 1;
+39:       pitch = totalSemitone - (octave * 12 + base);
+40:     }
+41: 
+42:     return { octave, pitch };
+43:   }
+44: 
+45:   private getTotalSemitone(): number {
+46:     return this.octave * 12 + Note.letterSemitones[this.letter] + this.pitch;
+47:   }
+48: 
+49:   public getSemitone(letter: string): number {
+50:     return Note.letterSemitones[letter];
+51:   }
+52: 
+53:   public getPitch(): number {
+54:     return this.pitch;
+55:   }
+56: 
+57:   public setPitch(newOctave: number): void {
+58:     this.pitch = newOctave;
+59:   }
+60: 
+61:   public getLetter(): string {
+62:     return this.letter;
+63:   }
+64: 
+65:   public setLetter(newNote: string): void {
+66:     this.letter = newNote;
+67:   }
+68: 
+69:   public getOctave(): number {
+70:     return this.octave;
+71:   }
+72: 
+73:   public setOctave(newOctave: number): void {
+74:     this.octave = newOctave;
+75:   }
+76: 
+77:   public transposeSemitone(distance: number): void {
+78:     if (distance === 0) {
+79:       return;
+80:     }
+81: 
+82:     if (distance > 0) {
+83:       for (let i = 0; i < distance; i++) {
+84:         this.raiseOneSemitone();
+85:       }
+86:     } else {
+87:       for (let i = 0; i < Math.abs(distance); i++) {
+88:         this.lowerOneSemitone();
+89:       }
+90:     }
+91:   }
+92: 
+93:   private raiseOneSemitone(): void {
+94:     const total = this.getTotalSemitone() + 1;
+95: 
+96:     if (this.pitch < 1) {
+97:       this.pitch += 1;
+98:       return;
+99:     }
+100: 
+101:     const currentIndex = Note.letterOrder.indexOf(this.letter);
+102:     const nextIndex = (currentIndex + 1) % Note.letterOrder.length;
+103:     const nextLetter = Note.letterOrder[nextIndex];
+104:     const { octave, pitch } = Note.resolveOctaveAndPitch(total, nextLetter);
+105: 
+106:     this.letter = nextLetter;
+107:     this.octave = octave;
+108:     this.pitch = pitch;
+109:   }
+110: 
+111:   private lowerOneSemitone(): void {
+112:     const total = this.getTotalSemitone() - 1;
+113: 
+114:     if (this.pitch > -1) {
+115:       this.pitch -= 1;
+116:       return;
+117:     }
+118: 
+119:     const currentIndex = Note.letterOrder.indexOf(this.letter);
+120:     const prevIndex = (currentIndex - 1 + Note.letterOrder.length) % Note.letterOrder.length;
+121:     const prevLetter = Note.letterOrder[prevIndex];
+122:     const { octave, pitch } = Note.resolveOctaveAndPitch(total, prevLetter);
+123: 
+124:     this.letter = prevLetter;
+125:     this.octave = octave;
+126:     this.pitch = pitch;
+127:   }
+128: 
+129:   public getAccidentalSymbol(): string {
+130:     if (this.pitch === 0) {
+131:       return '';
+132:     }
+133: 
+134:     if (this.pitch > 0) {
+135:       return '♯'.repeat(this.pitch);
+136:     }
+137: 
+138:     return '♭'.repeat(Math.abs(this.pitch));
+139:   }
+140: 
+141:   public addInterval(semitoneDistance: number, noteNumber: number) {
+142: 
+143:     let notes: string[] = ['C', "D", "E", "F", "G", "A", "H"];
+144: 
+145:     const targetNote: string = notes[((notes.indexOf(this.getLetter()) + (noteNumber - Math.sign(noteNumber)) % notes.length
+146:  + notes.length) % notes.length)];
+147:     console.log(`Target note: ${(notes.indexOf(this.getLetter()) + (noteNumber - Math.sign(noteNumber)) + notes.length) % notes.length}`);
+148:     let targetOctave: number = this.getOctave();
+149: 
+150:     let startNoteSemitone: number = this.getSemitone(this.getLetter()) + this.getPitch();
+151:     let targetNoteSemitone: number = this.getSemitone(targetNote);
+152: 
+153:     if (startNoteSemitone > targetNoteSemitone && semitoneDistance > 0) {
+154:       targetOctave += 1;
+155:       targetNoteSemitone += 12;
+156:     } else if (startNoteSemitone < targetNoteSemitone && semitoneDistance < 0) {
+157:       targetOctave -= 1;
+158:       targetNoteSemitone -= 12;
+159:     }
+160: 
+161:     if (semitoneDistance >= 12 || semitoneDistance <= -12) {
+162:       if (semitoneDistance >= 12) {
+163:         targetOctave += Math.floor(semitoneDistance / 12);
+164:       } else if (semitoneDistance <= -12) {
+165:         targetOctave += Math.ceil(semitoneDistance / 12);
+166:       }
+167:       semitoneDistance = semitoneDistance % 12;
+168:     }
+169: 
+170:     const naturalSemitoneOffset: number = (targetNoteSemitone - startNoteSemitone);
+171:     const difference: number = semitoneDistance - naturalSemitoneOffset;
+172: 
+173:     return new Note(difference, targetNote, targetOctave);
+174:   }
+175: 
+176:   toString(): string {
+177:     const letterName = this.letter;
+178:     const acc = this.pitch;
+179:     if (acc === 0) {
+180:       return letterName + `Octave: ${this.octave}`;
+181:     } else if (acc > 0) {
+182:       return letterName + 'is'.repeat(acc) + `Octave: ${this.octave}`;
+183:     } else {
+184:       const flats = -acc;
+185:       if (flats === 1) {
+186:         if (letterName === 'A' || letterName === 'E') return letterName + 's' + `Octave: ${this.octave}`;
+187:         if (letterName === 'H') return 'B' + `Octave: ${this.octave}`;
+188:         return letterName + 'es' + `Octave: ${this.octave}`;
+189:       } else {
+190:         let suffix = '';
+191:         if (letterName === 'A' || letterName === 'E') {
+192:           suffix = 's' + 'es'.repeat(flats - 1);
+193:         } else if (letterName === 'H') {
+194:           suffix = 'es'.repeat(flats);
+195:         } else {
+196:           suffix = 'es'.repeat(flats);
+197:         }
+198:         return letterName + suffix + `Octave: ${this.octave}`;
+199:       }
+200:     }
+201:   }
+202: 
+203:   public calculateUnison(): Note {
+204:     return this.addInterval(0, 1);
+205:   }
+206: 
+207:   public calculateMinorSecond(): Note {
+208:     return this.addInterval(1, 2);
+209:   }
+210: 
+211:   public calculateMajorSecond(): Note {
+212:     return this.addInterval(2, 2);
+213:   }
+214: 
+215:   public calculateMinorThird(): Note {
+216:     return this.addInterval(3, 3);
+217:   }
+218: 
+219:   public calculateMajorThird(): Note {
+220:     return this.addInterval(4, 3);
+221:   }
+222: 
+223:   public calculatePerfectFourth(): Note {
+224:     return this.addInterval(5, 4);
+225:   }
+226: 
+227:   public calculateAugmentedFourth(): Note {
+228:     return this.addInterval(6, 4);
+229:   }
+230: 
+231:   public calculateDiminishedFourth(): Note {
+232:     return this.addInterval(4, 4);
+233:   }
+234: 
+235:   public calculateDiminishedFifth(): Note {
+236:     return this.addInterval(6, 5);
+237:   }
+238: 
+239:   public calculatePerfectFifth(): Note {
+240:     return this.addInterval(7, 5);
+241:   }
+242: 
+243:   public calculateMinorSixth(): Note {
+244:     return this.addInterval(8, 6);
+245:   }
+246: 
+247:   public calculateMajorSixth(): Note {
+248:     return this.addInterval(9, 6);
+249:   }
+250: 
+251:   public calculateMinorSeventh(): Note {
+252:     return this.addInterval(10, 7);
+253:   }
+254: 
+255:   public calculateMajorSeventh(): Note {
+256:     return this.addInterval(11, 7);
+257:   }
+258: 
+259:   public calculatePerfectOctave(): Note {
+260:     return this.addInterval(12, 8);
+261:   }
+262: 
+263:   public calculateMinorNinth(): Note {
+264:     return this.addInterval(13, 9);
+265:   }
+266: 
+267:   public calculateMajorNinth(): Note {
+268:     return this.addInterval(14, 9);
+269:   }
+270: 
+271:   public calculateMinorTenth(): Note {
+272:     return this.addInterval(15, 10);
+273:   }
+274: 
+275:   public calculateMajorTenth(): Note {
+276:     return this.addInterval(16, 10);
+277:   }
+278: 
+279:   public calculatePerfectEleventh(): Note {
+280:     return this.addInterval(17, 11);
+281:   }
+282: 
+283:   public calculateAugmentedEleventh(): Note {
+284:     return this.addInterval(18, 11);
+285:   }
+286: 
+287:   public calculateDiminishedTwelfth(): Note {
+288:     return this.addInterval(18, 12);
+289:   }
+290: 
+291:   public calculatePerfectTwelfth(): Note {
+292:     return this.addInterval(19, 12);
+293:   }
+294: 
+295:   public calculateMinorThirteenth(): Note {
+296:     return this.addInterval(20, 13);
+297:   }
+298: 
+299:   public calculateMajorThirteenth(): Note {
+300:     return this.addInterval(21, 13);
+301:   }
+302: 
+303:   public calculateMinorFourteenth(): Note {
+304:     return this.addInterval(22, 14);
+305:   }
+306: 
+307:   public calculateMajorFourteenth(): Note {
+308:     return this.addInterval(23, 14);
+309:   }
+310: 
+311:   public calculatePerfectFifteenth(): Note {
+312:     return this.addInterval(24, 15);
+313:   }
+314: 
+315:   public calculateKwintaDown(): Note {
+316:     return this.addInterval(-7, -5);
+317:   }
+318: }

--- a/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.css
+++ b/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.css
@@ -1,0 +1,73 @@
+:host {
+  display: block;
+}
+
+.note-actions {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid #d5d5d5;
+  border-radius: 8px;
+  background-color: #f9f9fb;
+  max-width: 360px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.note-actions h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.1rem;
+}
+
+.note-actions__label {
+  margin: 0 0 1rem 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.note-actions__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.note-actions__buttons button {
+  padding: 0.5rem 0.9rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: #1976d2;
+  color: #ffffff;
+  transition: background-color 0.2s ease;
+}
+
+.note-actions__buttons button:hover {
+  background-color: #145ca3;
+}
+
+.note-actions__buttons button:focus-visible {
+  outline: 2px solid #0d47a1;
+  outline-offset: 2px;
+}
+
+.note-actions__delete {
+  background-color: #d32f2f;
+}
+
+.note-actions__delete:hover {
+  background-color: #b71c1c;
+}
+
+.note-actions__secondary {
+  background-color: #e0e0e0;
+  color: #2f2f2f;
+}
+
+.note-actions__secondary:hover {
+  background-color: #c7c7c7;
+}
+
+.note-actions__secondary:focus-visible {
+  outline: 2px solid #757575;
+  outline-offset: 2px;
+}

--- a/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.html
+++ b/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.html
@@ -1,5 +1,24 @@
 <div>
   <h2>Przykład notacji muzycznej</h2>
   <div #staff></div>
+
+  <div class="note-actions" *ngIf="(selectedNote$ | async) as selection">
+    <h3>Selected note</h3>
+    <p class="note-actions__label">{{ formatNote(selection.note) }}</p>
+    <div class="note-actions__buttons">
+      <button type="button" (click)="lowerSelected()">Lower ½ tone</button>
+      <button type="button" (click)="raiseSelected()">Raise ½ tone</button>
+      <button type="button" class="note-actions__delete" (click)="deleteSelected()">
+        Delete note
+      </button>
+      <button
+        type="button"
+        class="note-actions__secondary"
+        (click)="clearSelection()"
+      >
+        Close
+      </button>
+    </div>
+  </div>
 </div>
   

--- a/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.html
+++ b/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.html
@@ -1,13 +1,12 @@
 <div>
-  <h2>Przykład notacji muzycznej</h2>
   <div #staff></div>
 
   <div class="note-actions" *ngIf="(selectedNote$ | async) as selection">
-    <h3>Selected note</h3>
+    <h3>Wybrana nuta</h3>
     <p class="note-actions__label">{{ formatNote(selection.note) }}</p>
     <div class="note-actions__buttons">
-      <button type="button" (click)="lowerSelected()">Lower ½ tone</button>
-      <button type="button" (click)="raiseSelected()">Raise ½ tone</button>
+      <button type="button" (click)="lowerSelected()">Obniż ½ tonu (bemol)</button>
+      <button type="button" (click)="raiseSelected()">Podwyższ ½ tonu (krzyżyk)</button>
       <button type="button" class="note-actions__delete" (click)="deleteSelected()">
         Delete note
       </button>

--- a/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.ts
+++ b/frontend/antract-frontend/src/app/visual-lessons/visual-lessons.component.ts
@@ -1,18 +1,46 @@
+import { CommonModule } from '@angular/common';
 import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
+import { Observable } from 'rxjs';
 import { DrawService } from '../drawing/draw.service';
+import { Note } from '../services/Note';
 
 @Component({
   selector: 'app-visual-lessons',
+  imports: [CommonModule],
   templateUrl: './visual-lessons.component.html',
   styleUrl: './visual-lessons.component.css'
 })
 export class VisualLessonsComponent implements AfterViewInit {
   @ViewChild('staff', { static: true }) staffDiv!: ElementRef;
 
-  constructor(private drawService: DrawService) {}
+  public readonly selectedNote$: Observable<{ note: Note; index: number } | null>;
+
+  constructor(private drawService: DrawService) {
+    this.selectedNote$ = this.drawService.selectedNote$;
+  }
 
   ngAfterViewInit(): void {
     this.drawService.init(this.staffDiv);
+  }
+
+  public deleteSelected(): void {
+    this.drawService.deleteSelectedNote();
+  }
+
+  public raiseSelected(): void {
+    this.drawService.transposeSelected(1);
+  }
+
+  public lowerSelected(): void {
+    this.drawService.transposeSelected(-1);
+  }
+
+  public clearSelection(): void {
+    this.drawService.clearSelection();
+  }
+
+  public formatNote(note: Note): string {
+    return `${note.getLetter()}${note.getAccidentalSymbol()}${note.getOctave()}`;
   }
 }
 

--- a/frontend/tmp.html
+++ b/frontend/tmp.html
@@ -1,0 +1,816 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="UTF-8">
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+	    
+<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+	<!-- This site is optimized with the Yoast SEO plugin v18.2 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>CMUSE - Music News and Entertainment</title>
+	<meta name="description" content="Music articles and reviews covering genres such as classical, jazz, rock and pop, along with some music fun, music tech, inspiring stories, lists &amp; quizzes." />
+	<link rel="canonical" href="https://www.cmuse.org/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="CMUSE - Music News and Entertainment" />
+	<meta property="og:description" content="Interesting, Inspiring and Funny facts about music and musicians." />
+	<meta property="og:url" content="https://www.cmuse.org/" />
+	<meta property="og:site_name" content="CMUSE" />
+	<meta property="article:publisher" content="https://www.facebook.com/ClassicalMusicians" />
+	<meta property="article:modified_time" content="2024-04-09T03:44:02+00:00" />
+	<meta name="twitter:card" content="summary" />
+	
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//scripts.mediavine.com' />
+<link rel='dns-prefetch' href='//accounts.google.com' />
+<link rel='dns-prefetch' href='//apis.google.com' />
+<link rel='dns-prefetch' href='//maps.googleapis.com' />
+<link rel='dns-prefetch' href='//maps.gstatic.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel='dns-prefetch' href='//fonts.gstatic.com' />
+<link rel='dns-prefetch' href='//ajax.googleapis.com' />
+<link rel='dns-prefetch' href='//google-analytics.com' />
+<link rel='dns-prefetch' href='//www.google-analytics.com' />
+<link rel='dns-prefetch' href='//ssl.google-analytics.com' />
+<link rel='dns-prefetch' href='//youtube.com' />
+<link rel='dns-prefetch' href='//api.pinterest.com' />
+<link rel='dns-prefetch' href='//cdnjs.cloudflare.com' />
+<link rel='dns-prefetch' href='//pixel.wp.com' />
+<link rel='dns-prefetch' href='//connect.facebook.net' />
+<link rel='dns-prefetch' href='//sitename.disqus.com' />
+<link rel='dns-prefetch' href='//s0.wp.com' />
+<link rel='dns-prefetch' href='//s.gravatar.com' />
+<link rel='dns-prefetch' href='//stats.wp.com' />
+
+<link rel="alternate" type="application/rss+xml" title="CMUSE &raquo; Feed" href="https://www.cmuse.org/feed/" />
+<link rel="alternate" type="application/rss+xml" title="CMUSE &raquo; Comments Feed" href="https://www.cmuse.org/comments/feed/" />
+
+	<link rel='stylesheet' id='wp-block-library-css'  href='https://www.cmuse.org/wp-includes/css/dist/block-library/style.min.css?ver=5.9.12' media='all' />
+
+<link rel='stylesheet' id='font-awesome-four-css'  href='https://www.cmuse.org/wp-content/plugins/font-awesome-4-menus/css/font-awesome.min.css?ver=4.7.0' media='all' />
+<link rel='stylesheet' id='tve_style_family_tve_flt-css'  href='https://www.cmuse.org/wp-content/plugins/thrive-visual-editor/editor/css/thrive_flat.css?ver=3.30' media='all' />
+<link rel='stylesheet' id='ppress-frontend-css'  href='https://www.cmuse.org/wp-content/plugins/wp-user-avatar/assets/css/frontend.min.css?ver=3.2.9' media='all' />
+<link rel='stylesheet' id='ppress-flatpickr-css'  href='https://www.cmuse.org/wp-content/plugins/wp-user-avatar/assets/flatpickr/flatpickr.min.css?ver=3.2.9' media='all' />
+<link rel='stylesheet' id='ppress-select2-css'  href='https://www.cmuse.org/wp-content/plugins/wp-user-avatar/assets/select2/select2.min.css?ver=5.9.12' media='all' />
+<link rel='stylesheet' id='generate-widget-areas-css'  href='https://www.cmuse.org/wp-content/themes/generatepress/assets/css/components/widget-areas.min.css?ver=3.1.3' media='all' />
+<link rel='stylesheet' id='generate-style-css'  href='https://www.cmuse.org/wp-content/themes/generatepress/assets/css/main.min.css?ver=3.1.3' media='all' />
+
+<link rel='stylesheet' id='tablepress-default-css'  href='https://www.cmuse.org/wp-content/plugins/tablepress/css/default.min.css?ver=1.14' media='all' />
+<link rel='stylesheet' id='generate-blog-columns-css'  href='https://www.cmuse.org/wp-content/plugins/gp-premium/blog/functions/css/columns.min.css?ver=2.1.2' media='all' />
+<link rel='stylesheet' id='generate-offside-css'  href='https://www.cmuse.org/wp-content/plugins/gp-premium/menu-plus/functions/css/offside.min.css?ver=2.1.2' media='all' />
+
+
+
+
+
+
+
+
+
+
+
+
+<link rel="https://api.w.org/" href="https://www.cmuse.org/wp-json/" /><link rel="alternate" type="application/json" href="https://www.cmuse.org/wp-json/wp/v2/pages/75" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.cmuse.org/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.cmuse.org/wp-includes/wlwmanifest.xml" /> 
+<meta name="generator" content="WordPress 5.9.12" />
+<link rel='shortlink' href='https://www.cmuse.org/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.cmuse.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.cmuse.org%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.cmuse.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.cmuse.org%2F&#038;format=xml" />
+<link type="text/css" rel="stylesheet" href="https://www.cmuse.org/wp-content/plugins/category-specific-rss-feed-menu/wp_cat_rss_style.css" />
+<link rel="icon" href="https://www.cmuse.org/wp-content/uploads/2022/03/cmuse-icon-150x150.jpg" sizes="32x32" />
+<link rel="icon" href="https://www.cmuse.org/wp-content/uploads/2022/03/cmuse-icon-300x300.jpg" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.cmuse.org/wp-content/uploads/2022/03/cmuse-icon-300x300.jpg" />
+<meta name="msapplication-TileImage" content="https://www.cmuse.org/wp-content/uploads/2022/03/cmuse-icon-300x300.jpg" />
+			 					
+		<noscript></noscript></head>
+
+<body data-rsssl=1 class="home page-template-default page page-id-75 wp-custom-logo wp-embed-responsive aawp-custom post-image-aligned-center slideout-enabled slideout-mobile sticky-menu-fade right-sidebar nav-below-header separate-containers header-aligned-left dropdown-hover" itemtype="https://schema.org/WebPage" itemscope>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-dark-grayscale"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0 0.49803921568627" /><feFuncG type="table" tableValues="0 0.49803921568627" /><feFuncB type="table" tableValues="0 0.49803921568627" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-grayscale"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0 1" /><feFuncG type="table" tableValues="0 1" /><feFuncB type="table" tableValues="0 1" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-purple-yellow"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0.54901960784314 0.98823529411765" /><feFuncG type="table" tableValues="0 1" /><feFuncB type="table" tableValues="0.71764705882353 0.25490196078431" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-blue-red"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0 1" /><feFuncG type="table" tableValues="0 0.27843137254902" /><feFuncB type="table" tableValues="0.5921568627451 0.27843137254902" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-midnight"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0 0" /><feFuncG type="table" tableValues="0 0.64705882352941" /><feFuncB type="table" tableValues="0 1" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-magenta-yellow"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0.78039215686275 1" /><feFuncG type="table" tableValues="0 0.94901960784314" /><feFuncB type="table" tableValues="0.35294117647059 0.47058823529412" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-purple-green"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0.65098039215686 0.40392156862745" /><feFuncG type="table" tableValues="0 1" /><feFuncB type="table" tableValues="0.44705882352941 0.4" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" width="0" height="0" focusable="false" role="none" style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;" ><defs><filter id="wp-duotone-blue-orange"><feColorMatrix color-interpolation-filters="sRGB" type="matrix" values=" .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 .299 .587 .114 0 0 " /><feComponentTransfer color-interpolation-filters="sRGB" ><feFuncR type="table" tableValues="0.098039215686275 1" /><feFuncG type="table" tableValues="0 0.66274509803922" /><feFuncB type="table" tableValues="0.84705882352941 0.41960784313725" /><feFuncA type="table" tableValues="1 1" /></feComponentTransfer><feComposite in2="SourceGraphic" operator="in" /></filter></defs></svg><a class="screen-reader-text skip-link" href="#content" title="Skip to content">Skip to content</a>		<header class="site-header grid-container" id="masthead" aria-label="Site"  itemtype="https://schema.org/WPHeader" itemscope>
+			<div class="inside-header grid-container">
+				<div class="site-logo">
+					<a href="https://www.cmuse.org/" title="CMUSE" rel="home">
+						<img  class="header-image is-logo-image" alt="CMUSE" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20300%20100'%3E%3C/svg%3E" title="CMUSE" data-lazy-srcset="https://www.cmuse.org/wp-content/uploads/2014/07/logo-cmuse.png 1x, https://www.cmuse.org/wp-content/uploads/2014/07/logo-cmuse.png 2x" width="300" height="100" data-lazy-src="https://www.cmuse.org/wp-content/uploads/2014/07/logo-cmuse.png" /><noscript><img  class="header-image is-logo-image" alt="CMUSE" src="https://www.cmuse.org/wp-content/uploads/2014/07/logo-cmuse.png" title="CMUSE" srcset="https://www.cmuse.org/wp-content/uploads/2014/07/logo-cmuse.png 1x, https://www.cmuse.org/wp-content/uploads/2014/07/logo-cmuse.png 2x" width="300" height="100" /></noscript>
+					</a>
+				</div>			</div>
+		</header>
+				<nav class="main-navigation grid-container sub-menu-right" id="site-navigation" aria-label="Primary"  itemtype="https://schema.org/SiteNavigationElement" itemscope>
+			<div class="inside-navigation grid-container">
+								<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">
+					<span class="gp-icon icon-menu-bars"><svg viewBox="0 0 512 512" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em"><path d="M0 96c0-13.255 10.745-24 24-24h464c13.255 0 24 10.745 24 24s-10.745 24-24 24H24c-13.255 0-24-10.745-24-24zm0 160c0-13.255 10.745-24 24-24h464c13.255 0 24 10.745 24 24s-10.745 24-24 24H24c-13.255 0-24-10.745-24-24zm0 160c0-13.255 10.745-24 24-24h464c13.255 0 24 10.745 24 24s-10.745 24-24 24H24c-13.255 0-24-10.745-24-24z" /></svg><svg viewBox="0 0 512 512" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em"><path d="M71.029 71.029c9.373-9.372 24.569-9.372 33.942 0L256 222.059l151.029-151.03c9.373-9.372 24.569-9.372 33.942 0 9.372 9.373 9.372 24.569 0 33.942L289.941 256l151.03 151.029c9.372 9.373 9.372 24.569 0 33.942-9.373 9.372-24.569 9.372-33.942 0L256 289.941l-151.029 151.03c-9.373 9.372-24.569 9.372-33.942 0-9.372-9.373-9.372-24.569 0-33.942L222.059 256 71.029 104.971c-9.372-9.373-9.372-24.569 0-33.942z" /></svg></span><span class="mobile-menu">Menu</span>				</button>
+				<div id="primary-menu" class="main-nav"><ul id="menu-td-header" class=" menu sf-menu"><li id="menu-item-146" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home current-menu-item page_item page-item-75 current_page_item menu-item-146"><a href="https://www.cmuse.org/" aria-current="page">HOME</a></li>
+<li id="menu-item-742" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-742"><a href="https://www.cmuse.org/category/classical/">CLASSICAL</a></li>
+<li id="menu-item-743" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-743"><a href="https://www.cmuse.org/category/inspirational-stories/">INSPIRATIONAL</a></li>
+<li id="menu-item-746" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-746"><a href="https://www.cmuse.org/category/lists/">LISTS</a></li>
+<li id="menu-item-17414" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17414"><a href="https://www.cmuse.org/music-promotion-service/">MUSIC PROMOTION</a></li>
+<li id="menu-item-17415" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17415"><a href="https://www.cmuse.org/music-interview-service/">MUSICIAN INTERVIEW</a></li>
+<li id="menu-item-13668" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13668"><a href="https://www.cmuse.org/contact-us/">CONTACT US</a></li>
+</ul></div>			</div>
+		</nav>
+		
+	<div class="site grid-container container hfeed" id="page">
+				<div class="site-content" id="content">
+			
+	<div class="content-area" id="primary">
+		<main class="site-main" id="main">
+			
+<article id="post-75" class="post-75 page type-page status-publish infinite-scroll-item mv-content-wrapper" itemtype="https://schema.org/CreativeWork" itemscope>
+	<div class="inside-article">
+		
+		<div class="entry-content" itemprop="text">
+			<div id="tve_flt" class="tve_flt tcb-style-wrap"><div id="tve_editor" class="tve_shortcode_editor tar-main-content" data-post-id="75"><div id="tve-sf-l1bqmyut" class="thrv_wrapper thrv-search-form overlay-icon" data-css="tve-u-17db458c9f2" data-tcb-events="" data-ct-name="Search 04" data-ct="search_form-55891" data-list="" data-display-d="none" data-position-d="left" data-editor-preview="1"><form class="tve-prevent-content-edit" role="search" method="get" action="https://www.cmuse.org">
+	<div class="thrv-sf-submit" data-button-layout="icon_text" data-css="">
+		<button type="submit">
+				<span class="tcb-sf-button-icon">
+					<span class="thrv_wrapper thrv_icon tve_no_drag tve_no_icons tcb-icon-inherit-style tcb-icon-display" data-css=""><svg class="tcb-icon" viewBox="0 0 512 512" data-id="icon-search-regular"><path d="M508.5 468.9L387.1 347.5c-2.3-2.3-5.3-3.5-8.5-3.5h-13.2c31.5-36.5 50.6-84 50.6-136C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c52 0 99.5-19.1 136-50.6v13.2c0 3.2 1.3 6.2 3.5 8.5l121.4 121.4c4.7 4.7 12.3 4.7 17 0l22.6-22.6c4.7-4.7 4.7-12.3 0-17zM208 368c-88.4 0-160-71.6-160-160S119.6 48 208 48s160 71.6 160 160-71.6 160-160 160z"></path></svg></span>
+				</span>
+			<span class="tve_btn_txt">Search</span>
+		</button>
+	</div>
+	<div class="thrv-sf-input thrv-sf-input-hide" data-css="">
+		<input type="search" placeholder="Type Here..." name="s" value=""/>
+	</div>
+			<input type="hidden" class="tcb_sf_post_type" name="tcb_sf_post_type[]" value="post" data-label="Post"/>
+			<input type="hidden" class="tcb_sf_post_type" name="tcb_sf_post_type[]" value="page" data-label="Page"/>
+	</form></div><div class="tcb-post-list tve-content-list thrv_wrapper" data-type="grid" data-pagination-type="none" data-pages_near_current="2" data-css="tve-u-17fd3fc22b4" data-total_post_count="1461" data-total_sticky_count="0" data-no_posts_text="There are no posts to display."><article id="post-61" class="post-61 post type-post status-publish format-standard has-post-thumbnail hentry category-classical tag-bayreuth-festival tag-music-trivia tag-orchestra-pit infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="61" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/when-was-the-orchestra-pit-invented-click-to-find-out/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/when-was-the-orchestra-pit-invented-click-to-find-out/" title="WHEN WAS THE ORCHESTRA PIT FIRST INVENTED?" data-css="tve-u-17fd3fc22be" class="">WHEN WAS THE ORCHESTRA PIT FIRST INVENTED?</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-27" class="post-27 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-music-fun tag-music-fun tag-music-trivia tag-pablo-picasso infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="27" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/stravinsky-and-picasso-funny-story/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/stravinsky-and-picasso-funny-story/" title="STRAVINSKY AND PICASSO – FUNNY STORY" data-css="tve-u-17fd3fc22be" class="">STRAVINSKY AND PICASSO – FUNNY STORY</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-64" class="post-64 post type-post status-publish format-standard has-post-thumbnail hentry category-classical tag-ensembles tag-string-quartet infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="64" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/classical-music-played-in-the-most-unusual-ways/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/classical-music-played-in-the-most-unusual-ways/" title="Classical Music Played in the Most Unusual Ways" data-css="tve-u-17fd3fc22be" class="">Classical Music Played in the Most Unusual Ways</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-284" class="post-284 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists tag-composers tag-enigma-variations infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="284" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/7-fun-and-interesting-facts-about-edward-elgar/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/7-fun-and-interesting-facts-about-edward-elgar/" title="7 Fun And Interesting Facts About Edward Elgar" data-css="tve-u-17fd3fc22be" class="">7 Fun And Interesting Facts About Edward Elgar</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-21719" class="post-21719 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="21719" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/famous-mandolin-players/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/famous-mandolin-players/" title="10 Famous Mandolin Players and their Mandolin Performance (Great Mandolinists)" data-css="tve-u-17fd3fc22be" class="">10 Famous Mandolin Players and their Mandolin Performance (Great Mandolinists)</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-221" class="post-221 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists category-most-popular tag-music-history tag-music-trivia tag-unusual-deaths-of-composers infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="221" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/20-most-unusual-deaths-of-composers-in-music/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/20-most-unusual-deaths-of-composers-in-music/" title="20 Most Unusual Deaths Of Composers In Music History" data-css="tve-u-17fd3fc22be" class="">20 Most Unusual Deaths Of Composers In Music History</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-24151" class="post-24151 post type-post status-publish format-standard has-post-thumbnail hentry category-classical infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="24151" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/beethoven-deafness/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/beethoven-deafness/" title="Beethoven’s Deafness: How Beethoven Became Deaf" data-css="tve-u-17fd3fc22be" class="">Beethoven’s Deafness: How Beethoven Became Deaf</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-21911" class="post-21911 post type-post status-publish format-standard has-post-thumbnail hentry category-classical infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="21911" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/the-orchestra-in-the-romantic-period/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/the-orchestra-in-the-romantic-period/" title="The Orchestra in the Romantic Period" data-css="tve-u-17fd3fc22be" class="">The Orchestra in the Romantic Period</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-288" class="post-288 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-jazz-rock-world category-lists category-most-popular tag-mario-kart tag-music-trivia tag-time-signatures infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="288" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/14-musical-works-in-the-most-unusual-time-signatures/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/14-musical-works-in-the-most-unusual-time-signatures/" title="14 Musical Works In The Most Unusual Time Signatures" data-css="tve-u-17fd3fc22be" class="">14 Musical Works In The Most Unusual Time Signatures</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-23576" class="post-23576 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="23576" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/famous-baroque-music-pieces/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/famous-baroque-music-pieces/" title="4 Famous Baroque Music Pieces You Should Listen To" data-css="tve-u-17fd3fc22be" class="">4 Famous Baroque Music Pieces You Should Listen To</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-24613" class="post-24613 post type-post status-publish format-standard has-post-thumbnail hentry category-classical infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="24613" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/when-was-music-invented/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/when-was-music-invented/" title="When was music invented" data-css="tve-u-17fd3fc22be" class="">When was music invented</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-23543" class="post-23543 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="23543" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/dramatic-classical-music/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/dramatic-classical-music/" title="6 Dramatic Classical Music Pieces You Should Know" data-css="tve-u-17fd3fc22be" class="">6 Dramatic Classical Music Pieces You Should Know</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-261" class="post-261 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-music-fun tag-violin infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="261" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/paganini-on-bike/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/paganini-on-bike/" title="Violinist Plays Paganini Caprice No. 5 … While Riding A Bicycle [VIDEO]" data-css="tve-u-17fd3fc22be" class="">Violinist Plays Paganini Caprice No. 5 … While Riding A Bicycle [VIDEO]</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-24302" class="post-24302 post type-post status-publish format-standard has-post-thumbnail hentry category-classical infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="24302" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/characteristics-of-renaissance-music/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/characteristics-of-renaissance-music/" title="Characteristics of Renaissance Music" data-css="tve-u-17fd3fc22be" class="">Characteristics of Renaissance Music</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-316" class="post-316 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists tag-music-fun tag-music-history tag-music-inspiration tag-rms-titanic infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="316" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/20-unexpected-acts-of-kindness-involving-famous-musicians/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/20-unexpected-acts-of-kindness-involving-famous-musicians/" title="20 Unexpected Acts Of Kindness Involving Famous Musicians" data-css="tve-u-17fd3fc22be" class="">20 Unexpected Acts Of Kindness Involving Famous Musicians</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-24389" class="post-24389 post type-post status-publish format-standard has-post-thumbnail hentry category-classical infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="24389" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/famous-renaissance-music-pieces-and-composers/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/famous-renaissance-music-pieces-and-composers/" title="6 Famous Renaissance Music Pieces and Composers" data-css="tve-u-17fd3fc22be" class="">6 Famous Renaissance Music Pieces and Composers</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-24602" class="post-24602 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="24602" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/famous-bassoon-players/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/famous-bassoon-players/" title="10 Famous Bassoon Players (Great Bassoonists)" data-css="tve-u-17fd3fc22be" class="">10 Famous Bassoon Players (Great Bassoonists)</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-23425" class="post-23425 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="23425" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/most-scary-classical-music-pieces/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/most-scary-classical-music-pieces/" title="6 Most Scary Pieces of Classical Music" data-css="tve-u-17fd3fc22be" class="">6 Most Scary Pieces of Classical Music</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-8463" class="post-8463 post type-post status-publish format-standard has-post-thumbnail hentry category-classical tag-hitler tag-music-festivals tag-salzburg-festival tag-second-world-war infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="8463" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/the-salzburg-festival-and-second-world-war/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/the-salzburg-festival-and-second-world-war/" title="The Salzburg Festival and World War II" data-css="tve-u-17fd3fc22be" class="">The Salzburg Festival and World War II</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-21963" class="post-21963 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="21963" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/best-beethoven-symphonies/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/best-beethoven-symphonies/" title="Beethoven’s Symphonies: Three of the Best Symphonies by Beethoven" data-css="tve-u-17fd3fc22be" class="">Beethoven’s Symphonies: Three of the Best Symphonies by Beethoven</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-23917" class="post-23917 post type-post status-publish format-standard has-post-thumbnail hentry category-classical infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="23917" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/bach-vs-handel/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/bach-vs-handel/" title="Bach vs Handel: The Two Extremely Famous Baroque Composers" data-css="tve-u-17fd3fc22be" class="">Bach vs Handel: The Two Extremely Famous Baroque Composers</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-20900" class="post-20900 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="20900" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/most-difficult-piano-pieces/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/most-difficult-piano-pieces/" title="9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)" data-css="tve-u-17fd3fc22be" class="">9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-21559" class="post-21559 post type-post status-publish format-standard has-post-thumbnail hentry category-classical category-lists infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="21559" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/famous-viola-players/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/famous-viola-players/" title="10 Famous Viola Players and their Viola Performance (Great Violist)" data-css="tve-u-17fd3fc22be" class="">10 Famous Viola Players and their Viola Performance (Great Violist)</a></span></h2></div></div>
+</div>
+
+
+
+
+</article><article id="post-9284" class="post-9284 post type-post status-publish format-standard has-post-thumbnail hentry category-classical tag-cello tag-piano infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="9284" data-selector=".post-wrapper">
+<a href="https://www.cmuse.org/the-piano-guys-a-sky-full-of-stars-coldplay/" class="tve-dynamic-link" dynamic-postlink="tcb_post_the_permalink" data-shortcode-id="20900"><div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad tcb-local-vars-root" data-css="tve-u-17fd3fc22b7">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22b8" style=""></div>
+	<div class="tve-cb" data-css="tve-u-17fd3fc22b9"></div>
+</div></a>
+
+
+
+<div class="thrv_wrapper thrv_contentbox_shortcode thrv-content-box tve-elem-default-pad" data-css="tve-u-17fd3fc22ba">
+	<div class="tve-content-box-background" data-css="tve-u-17fd3fc22bc"></div>
+	<div class="tve-cb"><div class="thrv_wrapper thrv_text_element" style=""><h2 class="" data-css="tve-u-17fd3fc22bd" style=""><span class="thrive-shortcode-content" data-attr-link="1" data-attr-rel="0" data-attr-target="0" data-extra_key="" data-option-inline="1" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-attr-css="tve-u-17fd3fc22be" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/most-difficult-piano-pieces/&quot;,&quot;title&quot;:&quot;9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)&quot;,&quot;data-css&quot;:&quot;tve-u-17fd3fc22be&quot;,&quot;class&quot;:&quot;&quot;}"><a href="https://www.cmuse.org/the-piano-guys-a-sky-full-of-stars-coldplay/" title="The Piano Guys cover A Sky Full of Stars" data-css="tve-u-17fd3fc22be" class="">The Piano Guys cover A Sky Full of Stars</a></span></h2></div></div>
+</div>
+
+
+
+
+</article></div><div class="thrv_wrapper thrv-divider" data-style-d="tve_sep-4" data-thickness-d="8" data-color-d="rgb(30, 30, 30)" data-css="tve-u-17fd4050589">
+	<hr class="tve_sep tve_sep-4" style="">
+</div><div class="thrv_wrapper thrv_text_element"><p><strong><span style="text-decoration: underline;">Composers</span></strong></p></div><div class="tcb-post-list tve-content-list thrv_wrapper" data-type="grid" data-pagination-type="none" data-pages_near_current="2" data-css="tve-u-17fd40dc958" data-total_post_count="37" data-total_sticky_count="0" data-disabled-links="1" data-no_posts_text="There are no posts to display."><article id="post-21144" class="post-21144 post type-post status-publish format-standard has-post-thumbnail hentry category-composer-facts infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="21144" data-selector=".post-wrapper">
+
+
+
+
+<div class="thrv_wrapper thrv_text_element" style="" data-css="tve-u-17fd4077110"><h2 class="" data-css="tve-u-17fd4077111"><span class="thrive-shortcode-content" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-extra_key="" data-attr-link="1" data-attr-target="0" data-attr-rel="0" data-option-inline="1" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/alban-berg-facts/&quot;,&quot;title&quot;:&quot;10 Alban Berg Facts – Interesting Facts About Alban Berg&quot;,&quot;class&quot;:&quot;&quot;}" data-attr-css=""><a href="https://www.cmuse.org/jean-sibelius-facts/" title="10 Jean Sibelius Facts – Interesting Facts About Jean Sibelius" data-css="" class="">10 Jean Sibelius Facts – Interesting Facts About Jean Sibelius</a></span></h2></div><div class="tcb-clear" data-css="tve-u-17fd4077112"><div class="thrv_wrapper thrv-divider" data-style="tve_sep-1" data-thickness="1" data-color="rgba(0, 143, 255, 0.45)" data-css="tve-u-17fd4077113">
+	<hr class="tve_sep tve_sep-1">
+</div></div>
+
+
+
+<div class="tcb-clear tcb-post-read-more-clear">
+	<div class="tcb-post-read-more thrv_wrapper tcb-with-icon tcb-flip tve_ea_thrive_animation tve_anim_forward" data-css="tve-u-17fd4077114" data-tcb_hover_state_parent="" style="">
+		<a href="https://www.cmuse.org/jean-sibelius-facts/" class="tcb-button-link tcb-post-read-more-link tve_evt_manager_listen tve_et_mouseover" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;mouseover&quot;,&quot;config&quot;:{&quot;anim&quot;:&quot;forward&quot;,&quot;loop&quot;:1},&quot;a&quot;:&quot;thrive_animation&quot;}]_TNEVE_BCT__"><span class="tcb-button-icon">
+	<div class="thrv_wrapper thrv_icon tve_no_drag tve_no_icons tcb-icon-inherit-style tcb-icon-display"><svg class="tcb-icon" viewBox="0 0 448 512" data-id="icon-long-arrow-right-light" data-name="">
+            <path d="M311.03 131.515l-7.071 7.07c-4.686 4.686-4.686 12.284 0 16.971L387.887 239H12c-6.627 0-12 5.373-12 12v10c0 6.627 5.373 12 12 12h375.887l-83.928 83.444c-4.686 4.686-4.686 12.284 0 16.971l7.071 7.07c4.686 4.686 12.284 4.686 16.97 0l116.485-116c4.686-4.686 4.686-12.284 0-16.971L328 131.515c-4.686-4.687-12.284-4.687-16.97 0z"></path>
+        </svg></div>
+</span>
+
+		<span class="tcb-button-texts">
+			<span class="tcb-button-text thrv-inline-text">View More</span>
+		</span>
+		</a>
+	</div>
+</div>
+<div class="tve-article-cover"><a class="tcb-article-cover-link" href="https://www.cmuse.org/jean-sibelius-facts/">10 Jean Sibelius Facts – Interesting Facts About Jean Sibelius</a></div></article><article id="post-66466" class="post-66466 post type-post status-publish format-standard has-post-thumbnail hentry category-composer-facts infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="66466" data-selector=".post-wrapper">
+
+
+
+
+<div class="thrv_wrapper thrv_text_element" style="" data-css="tve-u-17fd4077110"><h2 class="" data-css="tve-u-17fd4077111"><span class="thrive-shortcode-content" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-extra_key="" data-attr-link="1" data-attr-target="0" data-attr-rel="0" data-option-inline="1" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/alban-berg-facts/&quot;,&quot;title&quot;:&quot;10 Alban Berg Facts – Interesting Facts About Alban Berg&quot;,&quot;class&quot;:&quot;&quot;}" data-attr-css=""><a href="https://www.cmuse.org/what-instruments-did-louis-armstrong-play/" title="What Instrument Did Louis Armstrong Play?" data-css="" class="">What Instrument Did Louis Armstrong Play?</a></span></h2></div><div class="tcb-clear" data-css="tve-u-17fd4077112"><div class="thrv_wrapper thrv-divider" data-style="tve_sep-1" data-thickness="1" data-color="rgba(0, 143, 255, 0.45)" data-css="tve-u-17fd4077113">
+	<hr class="tve_sep tve_sep-1">
+</div></div>
+
+
+
+<div class="tcb-clear tcb-post-read-more-clear">
+	<div class="tcb-post-read-more thrv_wrapper tcb-with-icon tcb-flip tve_ea_thrive_animation tve_anim_forward" data-css="tve-u-17fd4077114" data-tcb_hover_state_parent="" style="">
+		<a href="https://www.cmuse.org/what-instruments-did-louis-armstrong-play/" class="tcb-button-link tcb-post-read-more-link tve_evt_manager_listen tve_et_mouseover" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;mouseover&quot;,&quot;config&quot;:{&quot;anim&quot;:&quot;forward&quot;,&quot;loop&quot;:1},&quot;a&quot;:&quot;thrive_animation&quot;}]_TNEVE_BCT__"><span class="tcb-button-icon">
+	<div class="thrv_wrapper thrv_icon tve_no_drag tve_no_icons tcb-icon-inherit-style tcb-icon-display"><svg class="tcb-icon" viewBox="0 0 448 512" data-id="icon-long-arrow-right-light" data-name="">
+            <path d="M311.03 131.515l-7.071 7.07c-4.686 4.686-4.686 12.284 0 16.971L387.887 239H12c-6.627 0-12 5.373-12 12v10c0 6.627 5.373 12 12 12h375.887l-83.928 83.444c-4.686 4.686-4.686 12.284 0 16.971l7.071 7.07c4.686 4.686 12.284 4.686 16.97 0l116.485-116c4.686-4.686 4.686-12.284 0-16.971L328 131.515c-4.686-4.687-12.284-4.687-16.97 0z"></path>
+        </svg></div>
+</span>
+
+		<span class="tcb-button-texts">
+			<span class="tcb-button-text thrv-inline-text">View More</span>
+		</span>
+		</a>
+	</div>
+</div>
+<div class="tve-article-cover"><a class="tcb-article-cover-link" href="https://www.cmuse.org/what-instruments-did-louis-armstrong-play/">What Instrument Did Louis Armstrong Play?</a></div></article><article id="post-20129" class="post-20129 post type-post status-publish format-standard has-post-thumbnail hentry category-composer-facts infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="20129" data-selector=".post-wrapper">
+
+
+
+
+<div class="thrv_wrapper thrv_text_element" style="" data-css="tve-u-17fd4077110"><h2 class="" data-css="tve-u-17fd4077111"><span class="thrive-shortcode-content" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-extra_key="" data-attr-link="1" data-attr-target="0" data-attr-rel="0" data-option-inline="1" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/alban-berg-facts/&quot;,&quot;title&quot;:&quot;10 Alban Berg Facts – Interesting Facts About Alban Berg&quot;,&quot;class&quot;:&quot;&quot;}" data-attr-css=""><a href="https://www.cmuse.org/benjamin-britten-facts/" title="10 Benjamin Britten Facts – Interesting Facts About Benjamin Britten" data-css="" class="">10 Benjamin Britten Facts – Interesting Facts About Benjamin Britten</a></span></h2></div><div class="tcb-clear" data-css="tve-u-17fd4077112"><div class="thrv_wrapper thrv-divider" data-style="tve_sep-1" data-thickness="1" data-color="rgba(0, 143, 255, 0.45)" data-css="tve-u-17fd4077113">
+	<hr class="tve_sep tve_sep-1">
+</div></div>
+
+
+
+<div class="tcb-clear tcb-post-read-more-clear">
+	<div class="tcb-post-read-more thrv_wrapper tcb-with-icon tcb-flip tve_ea_thrive_animation tve_anim_forward" data-css="tve-u-17fd4077114" data-tcb_hover_state_parent="" style="">
+		<a href="https://www.cmuse.org/benjamin-britten-facts/" class="tcb-button-link tcb-post-read-more-link tve_evt_manager_listen tve_et_mouseover" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;mouseover&quot;,&quot;config&quot;:{&quot;anim&quot;:&quot;forward&quot;,&quot;loop&quot;:1},&quot;a&quot;:&quot;thrive_animation&quot;}]_TNEVE_BCT__"><span class="tcb-button-icon">
+	<div class="thrv_wrapper thrv_icon tve_no_drag tve_no_icons tcb-icon-inherit-style tcb-icon-display"><svg class="tcb-icon" viewBox="0 0 448 512" data-id="icon-long-arrow-right-light" data-name="">
+            <path d="M311.03 131.515l-7.071 7.07c-4.686 4.686-4.686 12.284 0 16.971L387.887 239H12c-6.627 0-12 5.373-12 12v10c0 6.627 5.373 12 12 12h375.887l-83.928 83.444c-4.686 4.686-4.686 12.284 0 16.971l7.071 7.07c4.686 4.686 12.284 4.686 16.97 0l116.485-116c4.686-4.686 4.686-12.284 0-16.971L328 131.515c-4.686-4.687-12.284-4.687-16.97 0z"></path>
+        </svg></div>
+</span>
+
+		<span class="tcb-button-texts">
+			<span class="tcb-button-text thrv-inline-text">View More</span>
+		</span>
+		</a>
+	</div>
+</div>
+<div class="tve-article-cover"><a class="tcb-article-cover-link" href="https://www.cmuse.org/benjamin-britten-facts/">10 Benjamin Britten Facts – Interesting Facts About Benjamin Britten</a></div></article><article id="post-20159" class="post-20159 post type-post status-publish format-standard has-post-thumbnail hentry category-composer-facts infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="20159" data-selector=".post-wrapper">
+
+
+
+
+<div class="thrv_wrapper thrv_text_element" style="" data-css="tve-u-17fd4077110"><h2 class="" data-css="tve-u-17fd4077111"><span class="thrive-shortcode-content" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-extra_key="" data-attr-link="1" data-attr-target="0" data-attr-rel="0" data-option-inline="1" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/alban-berg-facts/&quot;,&quot;title&quot;:&quot;10 Alban Berg Facts – Interesting Facts About Alban Berg&quot;,&quot;class&quot;:&quot;&quot;}" data-attr-css=""><a href="https://www.cmuse.org/georges-bizet-facts/" title="10 Georges Bizet Facts – Interesting Facts About Georges Bizet" data-css="" class="">10 Georges Bizet Facts – Interesting Facts About Georges Bizet</a></span></h2></div><div class="tcb-clear" data-css="tve-u-17fd4077112"><div class="thrv_wrapper thrv-divider" data-style="tve_sep-1" data-thickness="1" data-color="rgba(0, 143, 255, 0.45)" data-css="tve-u-17fd4077113">
+	<hr class="tve_sep tve_sep-1">
+</div></div>
+
+
+
+<div class="tcb-clear tcb-post-read-more-clear">
+	<div class="tcb-post-read-more thrv_wrapper tcb-with-icon tcb-flip tve_ea_thrive_animation tve_anim_forward" data-css="tve-u-17fd4077114" data-tcb_hover_state_parent="" style="">
+		<a href="https://www.cmuse.org/georges-bizet-facts/" class="tcb-button-link tcb-post-read-more-link tve_evt_manager_listen tve_et_mouseover" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;mouseover&quot;,&quot;config&quot;:{&quot;anim&quot;:&quot;forward&quot;,&quot;loop&quot;:1},&quot;a&quot;:&quot;thrive_animation&quot;}]_TNEVE_BCT__"><span class="tcb-button-icon">
+	<div class="thrv_wrapper thrv_icon tve_no_drag tve_no_icons tcb-icon-inherit-style tcb-icon-display"><svg class="tcb-icon" viewBox="0 0 448 512" data-id="icon-long-arrow-right-light" data-name="">
+            <path d="M311.03 131.515l-7.071 7.07c-4.686 4.686-4.686 12.284 0 16.971L387.887 239H12c-6.627 0-12 5.373-12 12v10c0 6.627 5.373 12 12 12h375.887l-83.928 83.444c-4.686 4.686-4.686 12.284 0 16.971l7.071 7.07c4.686 4.686 12.284 4.686 16.97 0l116.485-116c4.686-4.686 4.686-12.284 0-16.971L328 131.515c-4.686-4.687-12.284-4.687-16.97 0z"></path>
+        </svg></div>
+</span>
+
+		<span class="tcb-button-texts">
+			<span class="tcb-button-text thrv-inline-text">View More</span>
+		</span>
+		</a>
+	</div>
+</div>
+<div class="tve-article-cover"><a class="tcb-article-cover-link" href="https://www.cmuse.org/georges-bizet-facts/">10 Georges Bizet Facts – Interesting Facts About Georges Bizet</a></div></article><article id="post-66951" class="post-66951 post type-post status-publish format-standard has-post-thumbnail hentry category-composer-facts infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="66951" data-selector=".post-wrapper">
+
+
+
+
+<div class="thrv_wrapper thrv_text_element" style="" data-css="tve-u-17fd4077110"><h2 class="" data-css="tve-u-17fd4077111"><span class="thrive-shortcode-content" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-extra_key="" data-attr-link="1" data-attr-target="0" data-attr-rel="0" data-option-inline="1" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/alban-berg-facts/&quot;,&quot;title&quot;:&quot;10 Alban Berg Facts – Interesting Facts About Alban Berg&quot;,&quot;class&quot;:&quot;&quot;}" data-attr-css=""><a href="https://www.cmuse.org/what-instruments-did-claude-debussy-play/" title="What Instruments Did Claude Debussy Play?" data-css="" class="">What Instruments Did Claude Debussy Play?</a></span></h2></div><div class="tcb-clear" data-css="tve-u-17fd4077112"><div class="thrv_wrapper thrv-divider" data-style="tve_sep-1" data-thickness="1" data-color="rgba(0, 143, 255, 0.45)" data-css="tve-u-17fd4077113">
+	<hr class="tve_sep tve_sep-1">
+</div></div>
+
+
+
+<div class="tcb-clear tcb-post-read-more-clear">
+	<div class="tcb-post-read-more thrv_wrapper tcb-with-icon tcb-flip tve_ea_thrive_animation tve_anim_forward" data-css="tve-u-17fd4077114" data-tcb_hover_state_parent="" style="">
+		<a href="https://www.cmuse.org/what-instruments-did-claude-debussy-play/" class="tcb-button-link tcb-post-read-more-link tve_evt_manager_listen tve_et_mouseover" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;mouseover&quot;,&quot;config&quot;:{&quot;anim&quot;:&quot;forward&quot;,&quot;loop&quot;:1},&quot;a&quot;:&quot;thrive_animation&quot;}]_TNEVE_BCT__"><span class="tcb-button-icon">
+	<div class="thrv_wrapper thrv_icon tve_no_drag tve_no_icons tcb-icon-inherit-style tcb-icon-display"><svg class="tcb-icon" viewBox="0 0 448 512" data-id="icon-long-arrow-right-light" data-name="">
+            <path d="M311.03 131.515l-7.071 7.07c-4.686 4.686-4.686 12.284 0 16.971L387.887 239H12c-6.627 0-12 5.373-12 12v10c0 6.627 5.373 12 12 12h375.887l-83.928 83.444c-4.686 4.686-4.686 12.284 0 16.971l7.071 7.07c4.686 4.686 12.284 4.686 16.97 0l116.485-116c4.686-4.686 4.686-12.284 0-16.971L328 131.515c-4.686-4.687-12.284-4.687-16.97 0z"></path>
+        </svg></div>
+</span>
+
+		<span class="tcb-button-texts">
+			<span class="tcb-button-text thrv-inline-text">View More</span>
+		</span>
+		</a>
+	</div>
+</div>
+<div class="tve-article-cover"><a class="tcb-article-cover-link" href="https://www.cmuse.org/what-instruments-did-claude-debussy-play/">What Instruments Did Claude Debussy Play?</a></div></article><article id="post-21430" class="post-21430 post type-post status-publish format-standard has-post-thumbnail hentry category-composer-facts infinite-scroll-item mv-content-wrapper post-wrapper thrv_wrapper thrive-animated-item " tcb_hover_state_parent="" data-id="21430" data-selector=".post-wrapper">
+
+
+
+
+<div class="thrv_wrapper thrv_text_element" style="" data-css="tve-u-17fd4077110"><h2 class="" data-css="tve-u-17fd4077111"><span class="thrive-shortcode-content" data-shortcode="tcb_post_title" data-shortcode-name="Post title" data-extra_key="" data-attr-link="1" data-attr-target="0" data-attr-rel="0" data-option-inline="1" data-attr-static-link="{&quot;className&quot;:&quot;&quot;,&quot;href&quot;:&quot;https://www.cmuse.org/alban-berg-facts/&quot;,&quot;title&quot;:&quot;10 Alban Berg Facts – Interesting Facts About Alban Berg&quot;,&quot;class&quot;:&quot;&quot;}" data-attr-css=""><a href="https://www.cmuse.org/gustav-holst-facts/" title="Gustav Holst: 10 Interesting Gustav Holst Facts" data-css="" class="">Gustav Holst: 10 Interesting Gustav Holst Facts</a></span></h2></div><div class="tcb-clear" data-css="tve-u-17fd4077112"><div class="thrv_wrapper thrv-divider" data-style="tve_sep-1" data-thickness="1" data-color="rgba(0, 143, 255, 0.45)" data-css="tve-u-17fd4077113">
+	<hr class="tve_sep tve_sep-1">
+</div></div>
+
+
+
+<div class="tcb-clear tcb-post-read-more-clear">
+	<div class="tcb-post-read-more thrv_wrapper tcb-with-icon tcb-flip tve_ea_thrive_animation tve_anim_forward" data-css="tve-u-17fd4077114" data-tcb_hover_state_parent="" style="">
+		<a href="https://www.cmuse.org/gustav-holst-facts/" class="tcb-button-link tcb-post-read-more-link tve_evt_manager_listen tve_et_mouseover" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;mouseover&quot;,&quot;config&quot;:{&quot;anim&quot;:&quot;forward&quot;,&quot;loop&quot;:1},&quot;a&quot;:&quot;thrive_animation&quot;}]_TNEVE_BCT__"><span class="tcb-button-icon">
+	<div class="thrv_wrapper thrv_icon tve_no_drag tve_no_icons tcb-icon-inherit-style tcb-icon-display"><svg class="tcb-icon" viewBox="0 0 448 512" data-id="icon-long-arrow-right-light" data-name="">
+            <path d="M311.03 131.515l-7.071 7.07c-4.686 4.686-4.686 12.284 0 16.971L387.887 239H12c-6.627 0-12 5.373-12 12v10c0 6.627 5.373 12 12 12h375.887l-83.928 83.444c-4.686 4.686-4.686 12.284 0 16.971l7.071 7.07c4.686 4.686 12.284 4.686 16.97 0l116.485-116c4.686-4.686 4.686-12.284 0-16.971L328 131.515c-4.686-4.687-12.284-4.687-16.97 0z"></path>
+        </svg></div>
+</span>
+
+		<span class="tcb-button-texts">
+			<span class="tcb-button-text thrv-inline-text">View More</span>
+		</span>
+		</a>
+	</div>
+</div>
+<div class="tve-article-cover"><a class="tcb-article-cover-link" href="https://www.cmuse.org/gustav-holst-facts/">Gustav Holst: 10 Interesting Gustav Holst Facts</a></div></article></div></div></div><div class="tcb_flag" style="display: none"></div>
+		</div>
+
+			</div>
+</article>
+		</main>
+	</div>
+
+	<div class="widget-area sidebar is-right-sidebar" id="right-sidebar">
+	<div class="inside-right-sidebar">
+		<aside id="custom_html-3" class="widget_text widget inner-padding widget_custom_html"><div class="textwidget custom-html-widget"><ul class="display-posts-listing"><li class="listing-item"><a class="title" href="https://www.cmuse.org/most-difficult-piano-pieces/">9 Most Difficult Piano Pieces of All Time (Hardest Piano Pieces)</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/easy-piano-songs-for-beginners/">21 Easy Piano Songs for Beginners (Music Videos)</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/characteristics-of-classical-music/">Characteristics of Classical Music: An introduction</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/hardest-violin-pieces/">4 Hardest Violin Pieces Ever Written (Most Difficult Violin Pieces)</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/albert-einstein-music/">Albert Einstein: His Musical Life</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/best-of-mozart/">The Best of Mozart (7 Beautiful Works by Wolfgang Amadeus Mozart)</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/differences-between-baroque-and-classical-music/">The Differences between Baroque and Classical music</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/history-of-music/">Brief History of Music: An Introduction</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/similarities-between-mozart-and-beethoven/">Similarities Between Mozart And Beethoven</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/left-handed-piano/">Left-Handed Piano: Challenge and Inspiration for One-Handed Pianist</a></li></ul>
+<ul class="display-posts-listing"><li class="listing-item"><a class="title" href="https://www.cmuse.org/fur-elise-difficulty/">How Hard Is Für Elise Difficulty | By Ludwig Van Beethoven</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/chopin-saddest-pieces/">5 Chopin Saddest Pieces You Must Listen To</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/shigeru-kawai-vs-steinway-piano/">Shigeru Kawai Vs Steinway Piano (Differences Between Shigeru Kawai And Steinway Piano)</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/well-tempered-vs-equal-tempered/">Well Tempered Vs Equal Tempered (Differences Between Well Tempered And Equal Tempered)</a></li><li class="listing-item"><a class="title" href="https://www.cmuse.org/orchestral-musicians-bring-whales-to-surface/">Orchestral Musicians Bring Whales To Surface – This Will Take Your Breath Away</a></li></ul></div></aside><aside id="custom_html-4" class="widget_text widget inner-padding widget_custom_html"><div class="textwidget custom-html-widget"><span style="--tl-form-height-m:472.984px;--tl-form-height-t:496.797px;--tl-form-height-d:496.797px;" class="tl-placeholder-f-type-shortcode_61014 tl-preload-form"><span></span></span></div></aside>	</div>
+</div>
+
+	</div>
+</div>
+
+
+<div class="site-footer grid-container">
+				<div id="footer-widgets" class="site footer-widgets">
+				<div class="footer-widgets-container grid-container">
+					<div class="inside-footer-widgets">
+							<div class="footer-widget-1">
+		<aside id="text-10" class="widget inner-padding widget_text">			<div class="textwidget"><p>CMUSE is a participant of the Amazon Services LLC Associates Program, an affiliate advertising program – it is designed to provide an aid for the websites in earning an advertisement fee – by means of advertising and linking to Amazon.com products.</p>
+<p>CMUSE is your music news and entertainment website. We provide you with the latest breaking news and videos straight from the music industry.</p>
+</div>
+		</aside>	</div>
+		<div class="footer-widget-2">
+		<aside id="text-12" class="widget inner-padding widget_text">			<div class="textwidget"><p><strong>Popular Categories</strong></p>
+<p><a href="https://www.cmuse.org/category/classical/" target="_blank" rel="nofollow noopener">CLASSICAL</a></p>
+<p><a href="https://www.cmuse.org/category/music-instrument-reviews/" target="_blank" rel="nofollow noopener">Music Instrument Reviews</a></p>
+<p><a href="https://www.cmuse.org/category/lessons-list/" target="_blank" rel="nofollow noopener">Lessons List</a></p>
+<p><a href="https://www.cmuse.org/category/jazz-rock-world/" target="_blank" rel="nofollow noopener">JAZZ, ROCK, POP</a></p>
+<p><a href="https://www.cmuse.org/category/guitar/" target="_blank" rel="nofollow noopener">Guitar</a></p>
+</div>
+		</aside>	</div>
+		<div class="footer-widget-3">
+		<aside id="text-11" class="widget inner-padding widget_text">			<div class="textwidget"><p><strong>Useful Links</strong></p>
+<p><a href="https://www.cmuse.org/us/" target="_blank" rel="nofollow noopener">About us</a></p>
+<p><a href="https://www.cmuse.org/privacy-policy/" target="_blank" rel="nofollow noopener">Privacy Policy</a></p>
+<p><a href="https://www.cmuse.org/terms-conditions/" target="_blank" rel="nofollow noopener">Term of Services</a></p>
+</div>
+		</aside>	</div>
+						</div>
+				</div>
+			</div>
+					<footer class="site-info" aria-label="Site"  itemtype="https://schema.org/WPFooter" itemscope>
+			<div class="inside-site-info grid-container">
+								<div class="copyright-bar">
+					&copy; 2025 CMUSE.org				</div>
+			</div>
+		</footer>
+		</div>
+
+		<nav id="generate-slideout-menu" class="main-navigation slideout-navigation" itemtype="https://schema.org/SiteNavigationElement" itemscope style="display: none;">
+			<div class="inside-navigation grid-container grid-parent">
+							</div><!-- .inside-navigation -->
+		</nav><!-- #site-navigation -->
+
+					<div class="slideout-overlay">
+									<button class="slideout-exit has-svg-icon">
+						<span class="gp-icon pro-close">
+				<svg viewBox="0 0 512 512" aria-hidden="true" role="img" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1em" height="1em">
+					<path d="M71.029 71.029c9.373-9.372 24.569-9.372 33.942 0L256 222.059l151.029-151.03c9.373-9.372 24.569-9.372 33.942 0 9.372 9.373 9.372 24.569 0 33.942L289.941 256l151.03 151.029c9.372 9.373 9.372 24.569 0 33.942-9.373 9.372-24.569 9.372-33.942 0L256 289.941l-151.029 151.03c-9.373 9.372-24.569 9.372-33.942 0-9.372-9.373-9.372-24.569 0-33.942L222.059 256 71.029 104.971c-9.372-9.373-9.372-24.569 0-33.942z" />
+				</svg>
+			</span>						<span class="screen-reader-text">Close</span>
+					</button>
+							</div>
+			
+<div class="tvd-toast tve-fe-message" style="display: none">
+	<div class="tve-toast-message tve-success-message">
+		<div class="tve-toast-icon-container">
+			<span class="tve_tick thrv-svg-icon"></span>
+		</div>
+		<div class="tve-toast-message-container"></div>
+	</div>
+</div><!-- Matomo -->
+
+<!-- End Matomo Code --><!-- Google tag (gtag.js) -->
+
+<link rel='stylesheet' id='tve_leads_forms-css'  href='//www.cmuse.org/wp-content/plugins/thrive-leads/editor-layouts/css/frontend.css?ver=3.28' media='all' />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!--[if lte IE 11]>
+
+<![endif]-->
+
+
+
+
+
+        
+        
+</body>
+</html>
+
+<!-- This website is like a Rocket, isn't it? Performance optimized by WP Rocket. Learn more: https://wp-rocket.me - Debug: cached@1759366429 -->


### PR DESCRIPTION
## Summary
- offset noteheads when drawing chords, render accidentals, and keep track of the currently selected note on the staff
- extend the Note model so notes can be transposed by semitone and expose their accidental symbols for rendering
- add a note action panel in the visual lessons view to delete or adjust the selected note via half-step controls

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Chrome binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c87f14aed4832f83d5cd16829255fe